### PR TITLE
Add `--project-regexp` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ prevent shipping late on a Friday, but still want to allow marking merge request
 More than one embargo period can be specified. Any merge request assigned to her
 during an embargo period, will be merged in only once all embargoes are over.
 
+## Restricting the list of projects marge-bot considers
+
+By default marge-bot will work on all projects that she is a member of.
+Sometimes it is useful to restrict a specific instance of marge-bot to a subset
+of projects. You can specify a regexp that projects must match (anchored at the
+start of the string) with `--project-regexp`.
+
+One use-case is if you want to use different configurations (e.g.
+--add-reviewers on one project, but not the others). A simple way of doing is
+run two instances of marge-bot passing `--add-reviewers --project-regexp
+project/with_reviewers` to the first instance and `--project-regexp
+(?!project/with_reviewers)` to the second ones. The latter regexp is a negative
+look-ahead and will match any string not starting with `project/with_reviewers`.
+
 ## Troubleshooting
 
 Marge-bot continuously logs what she is doing, so this is a good place to look

--- a/pinnedNixpkgs.nix
+++ b/pinnedNixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/smarkets/nixpkgs/archive/b2f82bbadc8157a7f68d2be62b9341a400d827a3.tar.gz") { }
+import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/90afb0c10fe6f437fca498298747b2bcb6a77d39.tar.gz") { }

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -176,6 +176,7 @@ class TestRebaseAndAccept(object):
             add_reviewers=options.add_reviewers,
             add_tested=options.add_tested,
             impersonate_approvers=options.reapprove,
+            project_regexp='.*',
         )
         return marge.job.MergeJob(bot=bot, project=project, merge_request=merge_request, repo=repo)
 


### PR DESCRIPTION
Main use case is running multiple instances of marge with different flags for different projects on the same repo. Beyond that it's mostly handy for debugging.