### PR TITLE
Prevent calls to approvals endpoint on CE

### DIFF
--- a/marge/approvals.py
+++ b/marge/approvals.py
@@ -7,12 +7,17 @@ class Approvals(gitlab.Resource):
     """Approval info for a MergeRequest."""
 
     def refetch_info(self):
-        if self._api.version().release >= (9, 2, 2):
+        gitlab_version = self._api.version()
+        if gitlab_version.release >= (9, 2, 2):
             approver_url = '/projects/{0.project_id}/merge_requests/{0.iid}/approvals'.format(self)
         else:
             # gitlab botched the v4 api before 9.2.3
             approver_url = '/projects/{0.project_id}/merge_requests/{0.id}/approvals'.format(self)
-        self._info = self._api.call(GET(approver_url))
+
+        if gitlab_version.is_ee:
+            self._info = self._api.call(GET(approver_url))
+        else:
+            self._info = dict(self._info, approvals_left=0, approved_by=[])
 
     @property
     def iid(self):

--- a/marge/gitlab.py
+++ b/marge/gitlab.py
@@ -212,3 +212,7 @@ class Version(namedtuple('Version', 'release edition')):
 
         release = tuple(int(number) for number in release_string.split('.'))
         return cls(release=release, edition=edition)
+
+    @property
+    def is_ee(self):
+        return self.edition == 'ee'

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -7,3 +7,7 @@ class TestVersion(object):
 
     def test_parse_no_edition(self):
         assert gitlab.Version.parse('9.4.0')  == gitlab.Version(release=(9, 4, 0), edition=None)
+
+    def test_is_ee(self):
+        assert gitlab.Version.parse('9.4.0-ee').is_ee
+        assert not gitlab.Version.parse('9.4.0').is_ee


### PR DESCRIPTION
The `/projects/id/merge_requests/iid/approvals` endpoint is only available in the Enterprise Edition. On CE, we can instead pretend that there are no approvals left.

See #30.