### PR TITLE
Better handling of temporary ssh-key files

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -96,12 +96,14 @@ def _secret_auth_token_and_ssh_key(options):
         yield auth_token.strip(), ssh_key_file
     else:
         with tempfile.NamedTemporaryFile(mode='w', prefix='ssh-key-') as env_ssh_key_file:
-            ssh_key = os.getenv('MARGE_SSH_KEY')
-            assert ssh_key, "You need to pass --ssh-key-file or set envvar MARGE_SSH_KEY"
-            env_ssh_key_file.write(ssh_key + '\n')
-            env_ssh_key_file.flush()
-            yield auth_token.strip(), env_ssh_key_file.name
-            env_ssh_key_file.close()
+            try:
+                ssh_key = os.getenv('MARGE_SSH_KEY')
+                assert ssh_key, "You need to pass --ssh-key-file or set envvar MARGE_SSH_KEY"
+                env_ssh_key_file.write(ssh_key + '\n')
+                env_ssh_key_file.flush()
+                yield auth_token.strip(), env_ssh_key_file.name
+            finally:
+                env_ssh_key_file.close()
 
 
 def main(args=sys.argv[1:]):

--- a/marge/app.py
+++ b/marge/app.py
@@ -91,15 +91,17 @@ def _secret_auth_token_and_ssh_key(options):
     else:
         auth_token = options.auth_token_file.readline()
 
-    with tempfile.NamedTemporaryFile(mode='w', prefix='ssh-key-') as env_ssh_key_file:
-        ssh_key_file = options.ssh_key_file
-        if not ssh_key_file:
+    ssh_key_file = options.ssh_key_file
+    if ssh_key_file:
+        yield auth_token.strip(), ssh_key_file
+    else:
+        with tempfile.NamedTemporaryFile(mode='w', prefix='ssh-key-') as env_ssh_key_file:
             ssh_key = os.getenv('MARGE_SSH_KEY')
             assert ssh_key, "You need to pass --ssh-key-file or set envvar MARGE_SSH_KEY"
             env_ssh_key_file.write(ssh_key + '\n')
             env_ssh_key_file.flush()
-            ssh_key_file = env_ssh_key_file.name
-        yield auth_token.strip(), ssh_key_file
+            yield auth_token.strip(), env_ssh_key_file.name
+            env_ssh_key_file.close()
 
 
 def main(args=sys.argv[1:]):


### PR DESCRIPTION
This solves two issues:

  1. Unnecessary ssh-key-xxxx files are created when a proper key file was given
  2. The former files are never removed.

Notice that the second happens since `NamedTemporaryFile` needs the file
to be explicitly closed before deleting it.

Fixes #38