### PR TITLE
Make CI waiting time configurable (+ option refactoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ This is useful for example if you automatically deploy from master and want to
 prevent shipping late on a Friday, but still want to allow marking merge requests as
 "to be merged on Monday": just assign them to `marge-bot` as any other day.
 
-More than one embargo period can be specified. Any merge request assigned to her
-during an embargo period, will be merged in only once all embargoes are over.
+More than one embargo period can be specified, separated by commas. Any merge
+request assigned to her during an embargo period, will be merged in only once all
+embargoes are over.
 
 ## Restricting the list of projects marge-bot considers
 

--- a/marge/app.py
+++ b/marge/app.py
@@ -63,11 +63,9 @@ def _parse_args(args):
     )
     arg(
         '--embargo',
-        type=str,
-        action='append',
-        metavar='INTERVAL',
-        default=[],
-        help='Time during which no merging is to take place, e.g. "Friday 1pm - Monday 9am".',
+        type=interval.IntervalUnion.from_human,
+        metavar='INTERVAL[,..]',
+        help='Time(s) during which no merging is to take place, e.g. "Friday 1pm - Monday 9am".',
     )
     arg(
         '--add-reviewers',
@@ -140,7 +138,7 @@ def main(args=sys.argv[1:]):
             project_regexp=options.project_regexp,
         )
 
-        for embargo in options.embargo:
-            marge_bot.embargo_intervals.append(interval.WeeklyInterval.from_human(embargo))
+        if options.embargo:
+            marge_bot.embargo_intervals = options.embargo
 
         marge_bot.start()

--- a/marge/app.py
+++ b/marge/app.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import tempfile
+from datetime import timedelta
 
 from . import bot
 from . import interval
@@ -87,6 +88,12 @@ def _parse_args(args):
         default='.*',
         help="Only process projects that match; e.g. 'some_group/.*' or '(?!exclude/me)'",
     )
+    arg(
+        '--max-ci-time-in-minutes',
+        type=int,
+        default=15,
+        help='How long to wait for CI to pass.',
+    )
     arg('--debug', action='store_true', help='Debug logging (includes all HTTP requests etc.)')
 
     return parser.parse_args(args)
@@ -136,6 +143,7 @@ def main(args=sys.argv[1:]):
                 add_reviewers=options.add_reviewers,
                 reapprove=options.impersonate_approvers,
                 embargo=options.embargo,
+                max_ci_waiting_time=timedelta(minutes=options.max_ci_time_in_minutes),
             )
         )
 

--- a/marge/app.py
+++ b/marge/app.py
@@ -136,9 +136,7 @@ def main(args=sys.argv[1:]):
             add_tested=options.add_tested,
             impersonate_approvers=options.impersonate_approvers,
             project_regexp=options.project_regexp,
+            embargo_intervals=options.embargo,
         )
-
-        if options.embargo:
-            marge_bot.embargo_intervals = options.embargo
 
         marge_bot.start()

--- a/marge/app.py
+++ b/marge/app.py
@@ -16,7 +16,6 @@ from . import gitlab
 from . import user as user_module
 
 
-
 def _parse_args(args):
     parser = argparse.ArgumentParser(description=__doc__)
 
@@ -128,15 +127,17 @@ def main(args=sys.argv[1:]):
         api = gitlab.Api(options.gitlab_url, auth_token)
         user = user_module.User.myself(api)
 
-        marge_bot = bot.Bot(
-            api=api,
+        config = bot.BotConfig(
             user=user,
             ssh_key_file=ssh_key_file,
-            add_reviewers=options.add_reviewers,
-            add_tested=options.add_tested,
-            impersonate_approvers=options.impersonate_approvers,
             project_regexp=options.project_regexp,
-            embargo_intervals=options.embargo,
+            merge_opts=bot.MergeJobOptions.default(
+                add_tested=options.add_tested,
+                add_reviewers=options.add_reviewers,
+                reapprove=options.impersonate_approvers,
+                embargo=options.embargo,
+            )
         )
 
+        marge_bot = bot.Bot(api=api, config=config)
         marge_bot.start()

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from . import git
 from . import merge_request as merge_request_module
 from . import store
+from .interval import IntervalUnion
 from .job import MergeJob, MergeJobOptions
 from .project import AccessLevel, Project
 
@@ -32,7 +33,7 @@ class Bot(object):
 
         self._ssh_key_file = ssh_key_file
 
-        self.embargo_intervals = []
+        self.embargo_intervals = IntervalUnion.empty()
 
         self._api = api
         self._user = user
@@ -112,4 +113,4 @@ class Bot(object):
 
     def during_merge_embargo(self):
         now = datetime.utcnow()
-        return any(interval.covers(now) for interval in self.embargo_intervals)
+        return self.embargo_intervals.covers(now)

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -98,8 +98,9 @@ class Bot(object):
                         raise
 
                     job = MergeJob(
-                        bot=self,
+                        api=self._api, user=self._user,
                         project=project, merge_request=merge_request, repo=repo,
+                        options=self.merge_options,
                     )
                     job.execute()
                 else:

--- a/marge/interval.py
+++ b/marge/interval.py
@@ -58,6 +58,24 @@ class WeeklyInterval(object):
     def __ne__(self, other):
         return not self == other
 
+    def __repr__(self):
+        pat = '{class_name}({from_weekday}, {from_time}, {to_weekday}, {to_time})'
+        if self._is_complement_interval:
+            return pat.format(
+                class_name=self.__class__.__name__,
+                from_weekday=self._to_weekday,
+                from_time=self._to_time,
+                to_weekday=self._from_weekday,
+                to_time=self._from_time,
+            )
+        else:
+            return pat.format(
+                class_name=self.__class__.__name__,
+                from_weekday=self._from_weekday,
+                from_time=self._from_time,
+                to_weekday=self._to_weekday,
+                to_time=self._to_time,
+            )
 
     @classmethod
     def from_human(cls, string):
@@ -74,12 +92,8 @@ class WeeklyInterval(object):
         to_weekday, to_time = parse_part(to_)
         return cls(from_weekday, from_time, to_weekday, to_time)
 
-
-
-
     def covers(self, date):
         return self._interval_covers(date) != self._is_complement_interval
-
 
     def _interval_covers(self, date):
         weekday = date.date().weekday()
@@ -96,3 +110,31 @@ class WeeklyInterval(object):
             return False
 
         return True
+
+
+class IntervalUnion(object):
+    def __init__(self, iterable):
+        self._intervals = list(iterable)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __repr__(self):
+        return '{o.__class__.__name__}({o._intervals})'.format(o=self)
+
+    @classmethod
+    def empty(cls):
+        return cls(())
+
+    @classmethod
+    def from_human(cls, string):
+        strings = string.split(',')
+        return cls(WeeklyInterval.from_human(s) for s in strings)
+
+    def covers(self, date):
+        return any(interval.covers(date) for interval in self._intervals)

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -1,7 +1,7 @@
 from datetime import time
 
 import maya
-from marge.interval import WeeklyInterval
+from marge.interval import IntervalUnion, WeeklyInterval
 
 def date(spec):
     return maya.parse(spec).datetime()
@@ -37,3 +37,33 @@ class TestWeekly(object):
         assert WeeklyInterval.from_human('Monday 9:00 - Friday@17:00') == working_hours
         assert WeeklyInterval.from_human('Mon@9:00-Fri@17:00') == working_hours
         assert not WeeklyInterval.from_human('Mon@9:00-Tue@17:00') == working_hours
+
+
+class TestIntervalUnion(object):
+    def test_empty(self):
+        empty_interval = IntervalUnion.empty()
+        assert empty_interval == IntervalUnion([])
+        assert not empty_interval.covers(date('Monday 5pm'))
+
+    def test_singleton(self):
+        weekly = WeeklyInterval('Mon', time(10, 00), 'Fri', time(18, 00))
+        interval = IntervalUnion([weekly])
+        assert interval.covers(date('Tuesday 3pm'))
+        assert not interval.covers(date('Sunday 5pm'))
+
+    def test_non_overlapping(self):
+        weekly_1 = WeeklyInterval('Mon', time(10, 00), 'Fri', time(18, 00))
+        weekly_2 = WeeklyInterval('Sat', time(12, 00), 'Sun', time(9, 00))
+        interval = IntervalUnion([weekly_1, weekly_2])
+        assert interval.covers(date('Tuesday 3pm'))
+        assert not interval.covers(date('Saturday 9am'))
+        assert interval.covers(date('Saturday 6pm'))
+        assert not interval.covers(date('Sunday 11am'))
+
+    def test_from_human(self):
+        weekly_1 = WeeklyInterval('Mon', time(10, 00), 'Fri', time(18, 00))
+        weekly_2 = WeeklyInterval('Sat', time(12, 00), 'Sun', time(9, 00))
+        interval = IntervalUnion([weekly_1, weekly_2])
+
+        assert interval == IntervalUnion.from_human('Mon@10am - Fri@6pm,Sat@12pm-Sunday 9am')
+        assert IntervalUnion([weekly_1]) == IntervalUnion.from_human('Mon@10am - Fri@6pm')

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -177,6 +177,7 @@ class TestRebaseAndAccept(object):
             add_tested=options.add_tested,
             impersonate_approvers=options.reapprove,
             project_regexp='.*',
+            embargo_intervals=None,
         )
         return marge.job.MergeJob(bot=bot, project=project, merge_request=merge_request, repo=repo)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 import marge.commit
-import marge.bot
 import marge.git
 import marge.gitlab
 import marge.job
@@ -169,17 +168,11 @@ class TestRebaseAndAccept(object):
         repo = Mock(marge.git.Repo)
         options = options or marge.job.MergeJobOptions.default()
         user = marge.user.User.myself(self.api)
-        bot = marge.bot.Bot(
-            api=self.api,
-            user=user,
-            ssh_key_file='id_rsa',
-            add_reviewers=options.add_reviewers,
-            add_tested=options.add_tested,
-            impersonate_approvers=options.reapprove,
-            project_regexp='.*',
-            embargo_intervals=None,
+        return marge.job.MergeJob(
+            api=api, user=user,
+            project=project, merge_request=merge_request, repo=repo,
+            options=options,
         )
-        return marge.job.MergeJob(bot=bot, project=project, merge_request=merge_request, repo=repo)
 
     def test_succeeds_first_time(self, time_sleep):
         api, mocklab = self.api, self.mocklab

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,9 +1,11 @@
 import contextlib
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
 
 import marge.commit
+import marge.interval
 import marge.git
 import marge.gitlab
 import marge.job
@@ -11,6 +13,7 @@ import marge.project
 import marge.user
 from marge.approvals import Approvals
 from marge.gitlab import GET, PUT
+from marge.job import MergeJobOptions
 from marge.merge_request import MergeRequest
 
 import tests.test_approvals as test_approvals
@@ -275,3 +278,20 @@ class TestRebaseAndAccept(object):
             job = self.make_job()
             job.execute()
         assert api.state == 'merged'
+
+
+class TestMergeJobOptions(object):
+    def test_default(self):
+        assert MergeJobOptions.default() == MergeJobOptions(
+            add_tested=False,
+            add_reviewers=False,
+            reapprove=False,
+            embargo=marge.interval.IntervalUnion.empty(),
+            max_ci_waiting_time=timedelta(minutes=15),
+        )
+
+    def test_default_ci_time(self):
+        three_min = timedelta(minutes=3)
+        assert MergeJobOptions.default(max_ci_waiting_time=three_min) == MergeJobOptions.default()._replace(
+            max_ci_waiting_time=three_min
+        )


### PR DESCRIPTION
At the moment, it was hard-coded that marge would wait 15 minutes for CI to finish. Different teams have different needs, so now this parameter can be set with  `--max-ci-time-in-minutes`, which defaults to 15.

In doing so, this PR also refactors the handling of configuration parameters, so that we don't need to keep an ever-growing list of arguments in the Bot constructor. In the process, we remove the dependency of `MergeJob` on `Bot` and modify the `--embargo` parameter so that it can now receive all the embargo times separated by commas. 