### PR TITLE
Better handling of failures when trying to merge

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -178,6 +178,13 @@ class MergeJob(object):
                     )
                 elif merge_request.state == 'closed':
                     raise CannotMerge('Someone closed the merge request while I was attempting to merge it.')
+                elif merge_request.state == 'merged':
+                    # We are not covering any observed behaviour here, but if at this
+                    # point the request is merged, our job is done, so no need to complain
+                    log.info('Merge request is already merged, someone was faster!')
+                    rebased_into_up_to_date_target_branch = True
+                else:
+                    raise CannotMerge("Gitlab refused to merge this request and I don't know why!")
             except gitlab.ApiError:
                 log.exception('Unanticipated ApiError from Gitlab on merge attempt')
                 raise CannotMerge('had some issue with gitlab, check my logs...')

--- a/marge/job.py
+++ b/marge/job.py
@@ -176,6 +176,8 @@ class MergeJob(object):
                         'GitLab refused to merge this branch. I suspect that a Push Rule or a git-hook '
                         'is rejecting my commits; maybe my email needs to be white-listed?'
                     )
+                elif merge_request.state == 'closed':
+                    raise CannotMerge('Someone closed the merge request while I was attempting to merge it.')
             except gitlab.ApiError:
                 log.exception('Unanticipated ApiError from Gitlab on merge attempt')
                 raise CannotMerge('had some issue with gitlab, check my logs...')

--- a/marge/job.py
+++ b/marge/job.py
@@ -164,6 +164,13 @@ class MergeJob(object):
                 else:
                     log.warning('For the record, merge request state is %r', merge_request.state)
                     raise
+            except gitlab.MethodNotAllowed as e:
+                log.warning('Not Allowed!: %s', e)
+                merge_request.refetch_info()
+                if merge_request.work_in_progress:
+                    raise CannotMerge(
+                        'The request was marked as WIP as I was processing it (maybe a WIP commit?)'
+                    )
             except gitlab.ApiError:
                 log.exception('Unanticipated ApiError from Gitlab on merge attempt')
                 raise CannotMerge('had some issue with gitlab, check my logs...')

--- a/marge/job.py
+++ b/marge/job.py
@@ -171,6 +171,11 @@ class MergeJob(object):
                     raise CannotMerge(
                         'The request was marked as WIP as I was processing it (maybe a WIP commit?)'
                     )
+                elif merge_request.state == 'reopened':
+                    raise CannotMerge(
+                        'GitLab refused to merge this branch. I suspect that a Push Rule or a git-hook '
+                        'is rejecting my commits; maybe my email needs to be white-listed?'
+                    )
             except gitlab.ApiError:
                 log.exception('Unanticipated ApiError from Gitlab on merge attempt')
                 raise CannotMerge('had some issue with gitlab, check my logs...')

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -267,6 +267,29 @@ class TestRebaseAndAccept(object):
         assert api.state == 'someone_else_merged'
         assert api.notes == []
 
+    def test_handles_request_becoming_wip_after_push(self, time_sleep):
+        api, mocklab = self.api, self.mocklab
+        rewritten_sha = mocklab.rewritten_sha
+        api.add_transition(
+            PUT(
+                '/projects/1234/merge_requests/54/merge',
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
+            ),
+            Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
+            from_state='passed', to_state='now_is_wip',
+        )
+        api.add_merge_request(
+            dict(mocklab.merge_request_info, work_in_progress=True),
+            from_state='now_is_wip',
+        )
+        message ='The request was marked as WIP as I was processing it (maybe a WIP commit?)'
+        with patch('marge.job.push_rebased_and_rewritten_version', side_effect=mocklab.push_rebased):
+            with mocklab.expected_failure(message):
+                job = self.make_job()
+                job.execute()
+        assert api.state == 'now_is_wip'
+        assert api.notes == ["I couldn't merge this branch: %s" % message]
+
     def test_wont_merge_wip_stuff(self, time_sleep):
         api, mocklab = self.api, self.mocklab
         wip_merge_request = dict(mocklab.merge_request_info, work_in_progress=True)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -316,6 +316,29 @@ class TestRebaseAndAccept(object):
         assert api.state == 'rejected_by_git_hook'
         assert api.notes == ["I couldn't merge this branch: %s" % message]
 
+    def test_guesses_git_hook_error_on_merge_refusal(self, time_sleep):
+        api, mocklab = self.api, self.mocklab
+        rewritten_sha = mocklab.rewritten_sha
+        api.add_transition(
+            PUT(
+                '/projects/1234/merge_requests/54/merge',
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
+            ),
+            Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
+            from_state='passed', to_state='oops_someone_closed_it',
+        )
+        api.add_merge_request(
+            dict(mocklab.merge_request_info, state='closed'),
+            from_state='oops_someone_closed_it',
+        )
+        message = 'Someone closed the merge request while I was attempting to merge it.'
+        with patch('marge.job.push_rebased_and_rewritten_version', side_effect=mocklab.push_rebased):
+            with mocklab.expected_failure(message):
+                job = self.make_job()
+                job.execute()
+        assert api.state == 'oops_someone_closed_it'
+        assert api.notes == ["I couldn't merge this branch: %s" % message]
+
     def test_wont_merge_wip_stuff(self, time_sleep):
         api, mocklab = self.api, self.mocklab
         wip_merge_request = dict(mocklab.merge_request_info, work_in_progress=True)


### PR DESCRIPTION
These commits improve the messages that marge-bot will leave on a merge-request when a merge attempts succeeds, based on cases we've seen in the past. E.g. this fixes #32 and fixes #33.