### PR TITLE
Add the --add-part-of option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ ktmpl ./deploy.yml \
    commits in the merge request as described in the next section.
 
 
-## Adding Reviewed-by: and Tested: messages to commits
+## Adding tags to commits
 Marge-bot supports automated addition of the following
-two [standardized git commit headers](https://www.kernel.org/doc/html/v4.11/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes):
+two [standardized git commit tags](https://www.kernel.org/doc/html/v4.11/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes):
 `Reviewed-by` and `Tested-by`. For the latter it uses `Marge Bot
 <$MERGE_REQUEST_URL>` as a slight abuse of the convention (here `Marge Bot` is
 the name of the `marge-bot` user in GitLab).
@@ -168,6 +168,11 @@ reasons:
 1. Seeing where stuff "came from" in a rebase-based workflow
 2. Knowing that a commit has been tested, which is e.g. important for bisection
    so you can easily and automatically `git bisect --skip` untested commits.
+
+Additionally, by using `--add-part-of`, all commits will be tagged with a link
+to the merge request on which they were merged. This is useful, for example,
+to go from a commit shown in `git blame` to the merge request on which it was
+introduced.
 
 ## Impersonating approvers
 If you want a full audit trail, you will configure Gitlab

--- a/README.md
+++ b/README.md
@@ -139,9 +139,10 @@ ktmpl ./deploy.yml \
    commits in the merge request as described in the next section.
 
 
-## Adding tags to commits
+## Adding Reviewed-by:, Tested: and Part-of: to commit messages
+
 Marge-bot supports automated addition of the following
-two [standardized git commit tags](https://www.kernel.org/doc/html/v4.11/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes):
+two [standardized git commit trailers](https://www.kernel.org/doc/html/v4.11/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes):
 `Reviewed-by` and `Tested-by`. For the latter it uses `Marge Bot
 <$MERGE_REQUEST_URL>` as a slight abuse of the convention (here `Marge Bot` is
 the name of the `marge-bot` user in GitLab).
@@ -155,24 +156,26 @@ target branch into your PR branch:
 Reviewed-by: A. Reviewer <a.reviewer@example.com>
 ```
 
-All existing `Reviewed-by:` tags on commits in the branch will be stripped. This
+All existing `Reviewed-by:` trailers on commits in the branch will be stripped. This
 feature requires marge to run with admin privileges due to a peculiarity of the
 GitLab API: only admin users can obtain email addresses of other users, even
 ones explicitly declared as public (strangely this limitation is particular to
 email, Skype handles etc. are visible to everyone).
 
-If you pass `--add-tested` the final commit in a PR will be tagged with
-`Tested-by: marge-bot <$MERGE_REQUEST_URL>`. This can be very useful for two
-reasons:
+If you pass `--add-tested` the final commit message in a PR will be tagged with
+`Tested-by: marge-bot <$MERGE_REQUEST_URL>` trailer. This can be very useful for
+two reasons:
 
 1. Seeing where stuff "came from" in a rebase-based workflow
 2. Knowing that a commit has been tested, which is e.g. important for bisection
    so you can easily and automatically `git bisect --skip` untested commits.
 
-Additionally, by using `--add-part-of`, all commits will be tagged with a link
-to the merge request on which they were merged. This is useful, for example,
-to go from a commit shown in `git blame` to the merge request on which it was
-introduced.
+Additionally, by using `--add-part-of`, all commit messages will be tagged with
+a `Part-of: <$MERGE_REQUEST_URL>` trailer to the merge request on which they
+were merged. This is useful, for example, to go from a commit shown in `git
+blame` to the merge request on which it was introduced or to easily revert a all
+commits introduced by a single Merge Request when using a fast-forward/rebase
+based merge workflow.
 
 ## Impersonating approvers
 If you want a full audit trail, you will configure Gitlab

--- a/deploy.yml
+++ b/deploy.yml
@@ -36,7 +36,11 @@ objects:
             - name: app
               image: "$(APP_IMAGE)"
               imagePullPolicy: Always
-              args: ["--gitlab-url=$(MARGE_GITLAB_URL)", "--impersonate-approvers", "--add-tested"]
+              args: ["--gitlab-url=$(MARGE_GITLAB_URL)",
+                     "--impersonate-approvers",
+                     "--add-tested",
+                     "--add-reviewed-by",
+                     "--add-part-of"]
               env:
                 - name: MARGE_AUTH_TOKEN
                   valueFrom:

--- a/marge/app.py
+++ b/marge/app.py
@@ -68,14 +68,19 @@ def _parse_args(args):
         help='Time(s) during which no merging is to take place, e.g. "Friday 1pm - Monday 9am".',
     )
     arg(
-        '--add-reviewers',
-        action='store_true',
-        help='add Reviewed-by: $approver for each approver of PR to each commit in PR'
-    )
-    arg(
         '--add-tested',
         action='store_true',
         help='add Tested: marge-bot <$PR_URL> for the final commit on branch after it passed CI',
+    )
+    arg(
+        '--add-part-of',
+        action='store_true',
+        help='add Part-of: <$PR_URL> to each commit in PR (except top commit when --add-tested is used)',
+    )
+    arg(
+        '--add-reviewers',
+        action='store_true',
+        help='add Reviewed-by: $approver for each approver of PR to each commit in PR',
     )
     arg(
         '--impersonate-approvers',
@@ -140,6 +145,7 @@ def main(args=sys.argv[1:]):
             project_regexp=options.project_regexp,
             merge_opts=bot.MergeJobOptions.default(
                 add_tested=options.add_tested,
+                add_part_of=options.add_part_of,
                 add_reviewers=options.add_reviewers,
                 reapprove=options.impersonate_approvers,
                 embargo=options.embargo,

--- a/marge/job.py
+++ b/marge/job.py
@@ -317,7 +317,7 @@ def push_rebased_and_rewritten_version(
             rewritten_sha = repo.tag_with_trailer(
                 trailer_name='Part-of',
                 trailer_values=[part_of],
-                branch=source_branch if tested_by is not None else (source_branch + '^'),
+                branch=source_branch,
                 start_commit='origin/' + target_branch,
             )
         branch_rewritten = True

--- a/marge/job.py
+++ b/marge/job.py
@@ -10,7 +10,7 @@ from .project import Project
 from .user import User
 
 class MergeJob(object):
-    def __init__(self, api, user, project, merge_request, repo, options):
+    def __init__(self, *, api, user, project, merge_request, repo, options):
         self._api = api
         self._user = user
         self._project = project
@@ -252,6 +252,7 @@ class MergeJob(object):
         return self.opts.embargo.covers(now)
 
 def push_rebased_and_rewritten_version(
+        *,
         repo,
         source_branch,
         target_branch,
@@ -368,7 +369,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', _job_options)):
 
     @classmethod
     def default(
-            cls,
+            cls, *,
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
             embargo=None, max_ci_waiting_time=None,
     ):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -397,6 +397,7 @@ class TestMergeJobOptions(object):
     def test_default(self):
         assert MergeJobOptions.default() == MergeJobOptions(
             add_tested=False,
+            add_part_of=False,
             add_reviewers=False,
             reapprove=False,
             embargo=marge.interval.IntervalUnion.empty(),


### PR DESCRIPTION
It will add a `Part-of: <PR_URL>` tag to every commit in the PR. However, if `--add-tested` is also specified, the top commit will be spared (since it would be redundant otherwise).

Fixes #25.