### PR TITLE
Fix check for the reapprove merge job option

### DIFF
--- a/marge/bot.py
+++ b/marge/bot.py
@@ -21,7 +21,7 @@ class Bot(object):
         opts = config.merge_opts
 
         if not user.is_admin:
-            assert not opts.impersonate_approvers, (
+            assert not opts.reapprove, (
                 "{0.username} is not an admin, can't impersonate!".format(user)
             )
             assert not opts.add_reviewers, (


### PR DESCRIPTION
I assume there may have been some confusion with the option as parsed with argparse and the attributes as part of MergeJobOptions.