### PR TITLE
URL encode branch names

### DIFF
--- a/marge/commit.py
+++ b/marge/commit.py
@@ -1,5 +1,7 @@
 import re
 
+from requests.utils import quote
+
 from . import gitlab
 
 
@@ -23,7 +25,7 @@ class Commit(gitlab.Resource):
         info = api.call(GET(
             '/projects/{project_id}/repository/branches/{branch}'.format(
                 project_id=project_id,
-                branch=branch,
+                branch=quote(branch, safe=''),
             ),
         ))['commit']
         return cls(api, info)

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -48,6 +48,11 @@ class TestProject(object):
         Commit.last_on_branch(project_id=1234, branch='foobar-branch', api=self.api)
         self.api.call.assert_called_once_with(GET('/projects/1234/repository/branches/foobar-branch'))
 
+    def test_last_on_branch_encoding(self):
+        self.api.call.side_effect = lambda *_, **__: {'commit': INFO}
+        Commit.last_on_branch(project_id=1234, branch='foo/bar', api=self.api)
+        self.api.call.assert_called_once_with(GET('/projects/1234/repository/branches/foo%2Fbar'))
+
     def test_properties(self):
         commit = Commit(api=self.api, info=INFO)
         assert commit.id == "6104942438c14ec7bd21c6cd5bd995272b3faff6"


### PR DESCRIPTION
Otherwise this will error if the branch contains a '/'.