### PR TITLE
Catch exception from early attempt to parse json in response

### DIFF
--- a/marge/gitlab.py
+++ b/marge/gitlab.py
@@ -19,7 +19,10 @@ class Api(object):
         log.debug('REQUEST: %s %s %r %r', method.__name__.upper(), url, headers, command.call_args)
         response = method(url, headers=headers, **command.call_args)
         log.debug('RESPONSE CODE: %s', response.status_code)
-        log.debug('RESPONSE BODY: %r', response.json())
+        try:
+            log.debug('RESPONSE BODY: %r', response.json())
+        except json.JSONDecodeError:
+            pass
 
         if response.status_code == 200:
             return command.extract(response.json()) if command.extract else response.json()


### PR DESCRIPTION
Currently attempts to log response.json() before verifying response status.