### PR TITLE
Use fetchFromGitHub to pin nixpkgs

### DIFF
--- a/pinnedNixpkgs.nix
+++ b/pinnedNixpkgs.nix
@@ -1,1 +1,9 @@
-import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/90afb0c10fe6f437fca498298747b2bcb6a77d39.tar.gz") { }
+let
+  fetchFromGitHub = (import <nixpkgs> {}).fetchFromGitHub;
+  pkgs = import (fetchFromGitHub {
+                   owner  = "NixOS";
+                   repo   = "nixpkgs";
+                   rev    = "90afb0c10fe6f437fca498298747b2bcb6a77d39";
+                   sha256 = "0mvzdw5aygi1vjnvm0bc8bp7iwb9rypiqg749m6a6km84m7srm0w";
+                 }) {};
+in pkgs


### PR DESCRIPTION
This means no network request will be needed after first download (the other way
to achieve that would be nix-1.12 and specify a sha256 in fetchTarball). The
fetchFromGitHub solution is a bit ugly in that it requires an existing version
of nixpkgs and not just `raw` nix, but that's probably more of theoretical
concern.