### PR TITLE
Hardcode utf-8

### DIFF
--- a/dockerize.nix
+++ b/dockerize.nix
@@ -13,8 +13,9 @@ dockerTools.buildImage {
   ${dockerTools.shadowSetup}
   mkdir -p /root/.ssh
   '';
-  contents = [marge pkgs.bash pkgs.coreutils pkgs.openssh];
+  contents = [marge pkgs.bash pkgs.coreutils pkgs.openssh pkgs.glibcLocales];
   config = {
     Entrypoint = [ "/bin/marge.app" ];
+    Env = ["LANG=en_US.UTF-8" ''LOCALE_ARCHIVE=/lib/locale/locale-archive''];
   };
 }

--- a/marge/git.py
+++ b/marge/git.py
@@ -144,7 +144,7 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file')):
 
 
 def _run(*args, env=None, check=False, timeout=None):
-    with subprocess.Popen(args, env=env, stdout=PIPE, stderr=PIPE) as process:
+    with subprocess.Popen([a.encode('utf-8') for a in args], env=env, stdout=PIPE, stderr=PIPE) as process:
         try:
             stdout, stderr = process.communicate(input, timeout=timeout)
         except TimeoutExpired:

--- a/marge/job.py
+++ b/marge/job.py
@@ -66,6 +66,7 @@ class MergeJob(object):
         except Exception:
             log.exception('Unexpected Exception')
             merge_request.comment("I'm broken on the inside, please somebody fix me... :cry:")
+            self.unassign_from_mr(merge_request)
             raise
 
     def rebase_and_accept(self, approvals):

--- a/marge/trailerfilter.py
+++ b/marge/trailerfilter.py
@@ -1,55 +1,61 @@
 #!/usr/bin/env python3
-"""Executable script to pass to git filter-branch --msgfilter to rewrite trailers."""
+"""Executable script to pass to git filter-branch --msgfilter to rewrite trailers.
+
+This treats everything (stdin, stdout, env) at the level of raw bytes which are
+assumed to be utf-8, or more specifically some ASCII superset, regardless of
+(possibly broken) LOCALE settings.
+
+"""
 import collections
 import os
 import re
 import sys
 
+stdin = sys.stdin.buffer
+stdout = sys.stdout.buffer
+stderr = sys.stderr.buffer
 
 def die(msg):
-    print('ERROR:', msg, file=sys.stderr)
+    print(b'ERROR:', msg, file=stderr)
     sys.exit(1)
-
 
 def drop_trailing_newlines(lines):
     while lines and not lines[-1]:
         del lines[-1]
 
-
 def remove_duplicates(trailers):
     return list(collections.OrderedDict((t, None) for t in trailers).keys())
 
+def rework_commit_message(commit_message, trailers):
+    if not commit_message:
+        die(b'Expected a non-empty commit message')
 
-if __name__ == '__main__':
-    stdin = sys.stdin
-    stdout = sys.stdout
-
-    TRAILERS = os.getenv('TRAILERS').split('\n') if os.getenv('TRAILERS') else []
-    assert all(':' in trailer for trailer in TRAILERS), TRAILERS
-    TRAILER_NAMES = [trailer.split(':', 1)[0].lower() for trailer in TRAILERS]
-
-    commit_message_lines = stdin.readlines()
-    original_commit_message = ''.join(commit_message_lines).strip()
-    if not original_commit_message:
-        die('Expected a non-empty commit message')
+    trailer_names = [trailer.split(b':', 1)[0].lower() for trailer in trailers]
 
     filtered_lines = [
-        line.rstrip() for line in commit_message_lines
-        if line.split(':', 1)[0].lower() not in TRAILER_NAMES
+        line.rstrip() for line in commit_message.split(b'\n')
+        if line.split(b':', 1)[0].lower() not in trailer_names
     ]
+
     reworked_lines = filtered_lines[:]
 
     drop_trailing_newlines(reworked_lines)
-    while len(reworked_lines) > 1 and re.match(r'^[A-Z][\w-]+: ', reworked_lines[-1]):
-        TRAILERS.insert(0, reworked_lines.pop())
+    while len(reworked_lines) > 1 and re.match(br'^[A-Z][\w-]+: ', reworked_lines[-1]):
+        trailers.insert(0, reworked_lines.pop())
     if not reworked_lines:
-        die("Your commit message seems to consist only of Trailers: " + original_commit_message)
+        die(b"Your commit message seems to consist only of Trailers: " + original_commit_message)
 
     drop_trailing_newlines(reworked_lines)
 
-    non_empty_trailers = remove_duplicates([t for t in TRAILERS if t.split(': ', 1)[1].strip()])
+    non_empty_trailers = remove_duplicates([t for t in trailers if t.split(b': ', 1)[1].strip()])
     if non_empty_trailers:
-        reworked_lines += [''] + non_empty_trailers
-    reworked_lines += ['']
-    s = '\n'.join(reworked_lines)
-    stdout.write(s)
+        reworked_lines += [b''] + non_empty_trailers
+    reworked_lines += [b'']
+    return b'\n'.join(reworked_lines)
+
+if __name__ == '__main__':
+    TRAILERS = os.environb[b'TRAILERS'].split(b'\n') if os.environb[b'TRAILERS'] else []
+    assert all(b':' in trailer for trailer in TRAILERS), TRAILERS
+    original_commit_message = stdin.read().strip()
+    new_commit_message = rework_commit_message(original_commit_message, TRAILERS)
+    stdout.write(new_commit_message)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -178,7 +178,7 @@ def mocked_stdout(stdout):
 
 def _filter_test(s, trailer_name, trailer_values):
     script = marge.git._filter_branch_script(trailer_name, trailer_values)
-    return subprocess.check_output(['sh', '-c', script], input=s.encode('utf-8')).decode('utf-8')
+    return subprocess.check_output([b'sh', b'-c', script.encode('utf-8')], input=s.encode('utf-8')).decode('utf-8')
 
 
 def test_filter():


### PR DESCRIPTION
This closes #53 by doing three things:

1. Fixing the locale of the docker image to be UTF-8 aware
2. Making it so that marge-bot is hardcoded to treat everything as some ascii-superset (and processes git messages etc. at the bytes level)
3. Make marge-bot unassign herself before crashing (so when run in a restarting container/service a problematic MR does not block the whole queue)
