### PR TITLE
Add feature to restrict marge to a specific branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,17 @@ project/with_reviewers` to the first instance and `--project-regexp
 (?!project/with_reviewers)` to the second ones. The latter regexp is a negative
 look-ahead and will match any string not starting with `project/with_reviewers`.
 
+## Restricting the list of branches marge-bot considers
+
+It is also possible to restrict the branches marge-bot watches for incoming
+merge requests. By default, marge-bot will process MRs targetted for any branch.
+You may specify a regexp that target branches must match with `--branch-regexp`.
+
+This could be useful, if for instance, you wanted to set a regular freeze
+interval on your master branches for releases. You could have one instance of
+marge-bot with `--embargo "Friday 1pm - Monday 9am" --branch-regexp master` and
+the other with `--branch-regexp (?!master)`. This would allow development to
+continue on other branches during the embargo on master.
 
 ## Some handy git aliases
 

--- a/marge/app.py
+++ b/marge/app.py
@@ -121,6 +121,12 @@ def _parse_args(args):
         default=time_interval('120s'),
         help='How long a single git operation can take (default 120s)'
     )
+    arg(
+        '--branch-regexp',
+        type=regexp,
+        default='.*',
+        help='Only process MRs whose target branches match the given regular expression.',
+    )
     arg('--debug', action='store_true', help='Debug logging (includes all HTTP requests etc.)')
 
     return parser.parse_args(args)
@@ -172,6 +178,7 @@ def main(args=sys.argv[1:]):
             ssh_key_file=ssh_key_file,
             project_regexp=options.project_regexp,
             git_timeout=options.git_timeout,
+            branch_regexp=options.branch_regexp,
             merge_opts=bot.MergeJobOptions.default(
                 add_tested=options.add_tested,
                 add_part_of=options.add_part_of,

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -75,10 +75,23 @@ class Bot(object):
                     user_id=self.user.id,
                     api=self._api
                 )
+                branch_regexp = self._config.branch_regexp
+                filtered_mrs = [mr for mr in my_merge_requests
+                                if branch_regexp.match(mr.target_branch)]
+                filtered_out = set(my_merge_requests) - set(filtered_mrs)
+                if filtered_out:
+                    log.debug(
+                        'MRs that match branch_regexp: %s',
+                        [mr.web_url for mr in filtered_mrs]
+                    )
+                    log.debug(
+                        'MRs that do not match branch_regexp: %s',
+                        [mr.web_url for mr in filtered_out]
+                    )
 
-                if my_merge_requests:
-                    log.info('Got %s requests to merge; will try to merge the oldest', len(my_merge_requests))
-                    merge_request = my_merge_requests[0]
+                if filtered_mrs:
+                    log.info('Got %s requests to merge; will try to merge the oldest', len(filtered_mrs))
+                    merge_request = filtered_mrs[0]
                     try:
                         repo = repo_manager.repo_for_project(project)
                     except git.GitError:
@@ -99,7 +112,8 @@ class Bot(object):
             time.sleep(time_to_sleep_in_secs)
 
 
-class BotConfig(namedtuple('BotConfig', 'user ssh_key_file project_regexp merge_opts git_timeout')):
+class BotConfig(namedtuple('BotConfig',
+                           'user ssh_key_file project_regexp merge_opts git_timeout branch_regexp')):
     pass
 
 MergeJobOptions = job.MergeJobOptions

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -133,6 +133,11 @@ def test_git_timeout():
         with main("--git-timeout '150 s'") as bot:
             assert bot.config.git_timeout == datetime.timedelta(seconds=150)
 
+def test_branch_regexp():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with main("--branch-regexp='foo.*bar'") as bot:
+            assert bot.config.branch_regexp == re.compile('foo.*bar')
+
 
 # FIXME: I'd reallly prefer this to be a doctest, but adding --doctest-modules
 # seems to seriously mess up the test run


### PR DESCRIPTION
Copies the same debug logging as `--project-regexp` when filtering. It makes use of the MRs web_url as it's easily identifiable.

This has been quite useful for the project I'm working on, since not only can CI last a long time, but we currently have two branches that are targetted for a high number of MRs. This has allowed us to run an instance of Marge for both of these branches, allowing for some fast and dirty parallelisation.