### PR TITLE
Reduce logging in non-debug

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -162,6 +162,8 @@ def main(args=sys.argv[1:]):
 
     if options.debug:
         logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger("requests").setLevel(logging.WARNING)
 
     with _secret_auth_token_and_ssh_key(options) as (auth_token, ssh_key_file):
         api = gitlab.Api(options.gitlab_url, auth_token)

--- a/marge/job.py
+++ b/marge/job.py
@@ -203,6 +203,7 @@ class MergeJob(object):
         time_0 = datetime.utcnow()
         waiting_time_in_secs = 10
 
+        log.info('Waiting for CI to pass')
         while datetime.utcnow() - time_0 < self._options.ci_timeout:
             ci_status = Commit.fetch_by_id(source_project_id, commit_sha, api).status
             if ci_status == 'success':
@@ -217,7 +218,7 @@ class MergeJob(object):
             if ci_status not in ('pending', 'running'):
                 log.warning('Suspicious build status: %r', ci_status)
 
-            log.info('Waiting for %s secs before polling CI status again', waiting_time_in_secs)
+            log.debug('Waiting for %s secs before polling CI status again', waiting_time_in_secs)
             time.sleep(waiting_time_in_secs)
 
         raise CannotMerge('CI is taking too long')


### PR DESCRIPTION
Logs can very quickly get swamped with new HTTPS connection from requests and CI polling messages. I understand that in most use cases, CI likely won't last too long, but these two messages take up the majority of the logs.