### PR TITLE
Sleep even less between polling for MRs

### DIFF
--- a/marge/bot.py
+++ b/marge/bot.py
@@ -47,6 +47,8 @@ class Bot(object):
         return self._api
 
     def _run(self, repo_manager):
+        time_to_sleep_between_projects_in_secs = 1
+        min_time_to_sleep_after_iterating_all_projects_in_secs = 30
         while True:
             log.info('Finding out my current projects...')
             my_projects = Project.fetch_all_mine(self._api)
@@ -104,12 +106,15 @@ class Bot(object):
                         options=self._config.merge_opts,
                     )
                     merge_job.execute()
-                    time_to_sleep_in_secs = 5
                 else:
                     log.info('Nothing to merge at this point...')
-                    time_to_sleep_in_secs = 30
-                log.info('Sleeping for %s seconds...', time_to_sleep_in_secs)
-                time.sleep(time_to_sleep_in_secs)
+                time.sleep(time_to_sleep_between_projects_in_secs)
+            big_sleep = max(0,
+                            min_time_to_sleep_after_iterating_all_projects_in_secs -
+                            time_to_sleep_between_projects_in_secs * len(filtered_projects))
+            log.info('Sleeping for %s seconds...', big_sleep)
+            time.sleep(big_sleep)
+
 
 
 


### PR DESCRIPTION
The logic is: we want to sleep at least 30 secs after iterating over all
projects (both so that people have a chance to undo accidental assignments to
marge and to not poll like crazy when nothing is happening to the repo). If
there are many projects, the current system sleeps too long, though. Let's just
sleep one sec between each by default and then make up the difference to the 30s
afterwards.