### PR TITLE
Add a merge strategy

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -151,6 +151,15 @@ def _parse_config(args):
         help='Only process MRs whose target branches match the given regular expression.\n',
     )
     parser.add_argument(
+        '--merge',
+        action='store_true',
+        help=(
+            'Use git merge instead of git rebase\n'
+            '(enable this is you use git merge as\n'
+            'git tends to misbehave when both are used)\n'
+        ),
+    )
+    parser.add_argument(
         '--debug',
         action='store_true',
         help='Debug logging (includes all HTTP requests etc).\n',
@@ -214,6 +223,7 @@ def main(args=sys.argv[1:]):
                 reapprove=options.impersonate_approvers,
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
+                merge=options.merge,
             )
         )
 

--- a/marge/app.py
+++ b/marge/app.py
@@ -100,7 +100,17 @@ def _parse_config(args):
         metavar='INTERVAL[,..]',
         help='Time(s) during which no merging is to take place, e.g. "Friday 1pm - Monday 9am".\n',
     )
-    parser.add_argument(
+    merge_group = parser.add_mutually_exclusive_group(required=False)
+    merge_group.add_argument(
+        '--use-merge-strategy',
+        action='store_true',
+        help=(
+            'Use git merge instead of git rebase\n'
+            '(enable this is you use git merge as\n'
+            'git tends to misbehave when both are used)\n'
+        ),
+    )
+    merge_group.add_argument(
         '--add-tested',
         action='store_true',
         help='Add "Tested: marge-bot <$MR_URL>" for the final commit on branch after it passed CI.\n',
@@ -149,15 +159,6 @@ def _parse_config(args):
         type=regexp,
         default='.*',
         help='Only process MRs whose target branches match the given regular expression.\n',
-    )
-    parser.add_argument(
-        '--merge',
-        action='store_true',
-        help=(
-            'Use git merge instead of git rebase\n'
-            '(enable this is you use git merge as\n'
-            'git tends to misbehave when both are used)\n'
-        ),
     )
     parser.add_argument(
         '--debug',
@@ -223,7 +224,7 @@ def main(args=sys.argv[1:]):
                 reapprove=options.impersonate_approvers,
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
-                merge=options.merge,
+                use_merge_strategy=options.use_merge_strategy,
             )
         )
 

--- a/marge/app.py
+++ b/marge/app.py
@@ -106,8 +106,7 @@ def _parse_config(args):
         action='store_true',
         help=(
             'Use git merge instead of git rebase\n'
-            '(enable this is you use git merge as\n'
-            'git tends to misbehave when both are used)\n'
+            'Enable if you use a workflow based on merge-commits and not linear history\n'
         ),
     )
     merge_group.add_argument(

--- a/marge/git.py
+++ b/marge/git.py
@@ -59,16 +59,16 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout')):
             raise
         return self.get_commit_hash()
 
-    def merge(self, branch, new_base, source_repo_url=None):
-        """Merge `new_base` into `branch` and return the new HEAD commit id.
+    def merge(self, source_branch, target_branch, source_repo_url=None):
+        """Merge `target_branch` into `source_branch` and return the new HEAD commit id.
 
-        By default `branch` and `new_base` are assumed to reside in the same
+        By default `source_branch` and `target_branch` are assumed to reside in the same
         repo as `self`. However, if `source_repo_url` is passed and not `None`,
-        `branch` is taken from there.
+        `source_branch` is taken from there.
 
         Throws a `GitError` if the merge fails. Will also try to --abort it.
         """
-        return self._fuse_branch('merge', branch, new_base, source_repo_url)
+        return self._fuse_branch('merge', source_branch, target_branch, source_repo_url)
 
     def rebase(self, branch, new_base, source_repo_url=None):
         """Rebase `new_base` into `branch` and return the new HEAD commit id.
@@ -81,8 +81,8 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout')):
         """
         return self._fuse_branch('rebase', branch, new_base, source_repo_url)
 
-    def _fuse_branch(self, strategy, branch, new_base, source_repo_url=None):
-        assert source_repo_url or branch != new_base, branch
+    def _fuse_branch(self, strategy, branch, target_branch, source_repo_url=None):
+        assert source_repo_url or branch != target_branch, branch
 
         self.git('fetch', 'origin')
         if source_repo_url:
@@ -98,7 +98,7 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout')):
             self.git('checkout', '-B', branch, 'origin/' + branch, '--')
 
         try:
-            self.git(strategy, 'origin/' + new_base)
+            self.git(strategy, 'origin/' + target_branch)
         except GitError:
             log.warning(strategy + ' failed, doing an --abort')
             self.git(strategy, '--abort')

--- a/marge/job.py
+++ b/marge/job.py
@@ -348,7 +348,7 @@ def push_merged_version(
         changes_pushed = True
     except git.GitError:
         if not branch_merged:
-            raise CannotMerge('got conflicts while rebasing, your problem now...')
+            raise CannotMerge('got conflicts while merging, your problem now...')
         if not branch_rewritten:
             raise CannotMerge('failed on filter-branch; check my logs!')
         if not changes_pushed:

--- a/marge/job.py
+++ b/marge/job.py
@@ -360,6 +360,7 @@ _job_options = [
     'reapprove',
     'embargo',
     'ci_timeout',
+    'merge',
 ]
 
 class MergeJobOptions(namedtuple('MergeJobOptions', _job_options)):
@@ -373,7 +374,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', _job_options)):
     def default(
             cls, *,
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
-            embargo=None, ci_timeout=None,
+            embargo=None, ci_timeout=None, merge=False
     ):
         embargo = embargo or IntervalUnion.empty()
         ci_timeout = ci_timeout or timedelta(minutes=15)
@@ -384,6 +385,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', _job_options)):
             reapprove=reapprove,
             embargo=embargo,
             ci_timeout=ci_timeout,
+            merge=merge,
         )
 
 

--- a/marge/job.py
+++ b/marge/job.py
@@ -108,7 +108,7 @@ class MergeJob(object):
             source_repo_url = None if source_project is self._project else source_project.ssh_url_to_repo
             # NB. this will be a no-op if there is nothing to rebase/rewrite
             target_sha, _rebased_sha, actual_sha = update_from_target_branch_and_push(
-                use_merge_strategy=self.opts.merge,
+                use_merge_strategy=self.opts.use_merge_strategy,
                 repo=self.repo,
                 source_branch=merge_request.source_branch,
                 target_branch=merge_request.target_branch,
@@ -336,13 +336,6 @@ def push_merged_version(
                 branch=source_branch,
                 start_commit='origin/' + target_branch,
             )
-        if tested_by is not None:
-            rewritten_sha = repo.tag_with_trailer(
-                trailer_name='Tested-by',
-                trailer_values=tested_by,
-                branch=source_branch,
-                start_commit=source_branch + '^'
-            )
         if part_of is not None:
             rewritten_sha = repo.tag_with_trailer(
                 trailer_name='Part-of',
@@ -482,7 +475,7 @@ _job_options = [
     'reapprove',
     'embargo',
     'ci_timeout',
-    'merge',
+    'use_merge_strategy',
 ]
 
 class MergeJobOptions(namedtuple('MergeJobOptions', _job_options)):
@@ -496,7 +489,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', _job_options)):
     def default(
             cls, *,
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
-            embargo=None, ci_timeout=None, merge=False
+            embargo=None, ci_timeout=None, use_merge_strategy=False
     ):
         embargo = embargo or IntervalUnion.empty()
         ci_timeout = ci_timeout or timedelta(minutes=15)
@@ -507,7 +500,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', _job_options)):
             reapprove=reapprove,
             embargo=embargo,
             ci_timeout=ci_timeout,
-            merge=merge,
+            use_merge_strategy=use_merge_strategy,
         )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -101,11 +101,23 @@ def test_embargo():
                embargo=interval.IntervalUnion.from_human('Fri 1pm-Mon 7am'),
             )
 
+def test_use_merge_strategy():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with main('--use-merge-strategy') as bot:
+            assert bot.config.merge_opts != job.MergeJobOptions.default()
+            assert bot.config.merge_opts == job.MergeJobOptions.default(use_merge_strategy=True)
+
 def test_add_tested():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with main('--add-tested') as bot:
             assert bot.config.merge_opts != job.MergeJobOptions.default()
             assert bot.config.merge_opts == job.MergeJobOptions.default(add_tested=True)
+
+def test_use_merge_strategy_and_add_tested_are_mutualy_exclusive():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with pytest.raises(SystemExit):
+            with main('--use-merge-strategy --add-tested') as bot:
+                pass
 
 def test_add_part_of():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
@@ -163,13 +175,6 @@ def test_branch_regexp():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with main("--branch-regexp='foo.*bar'") as bot:
             assert bot.config.branch_regexp == re.compile('foo.*bar')
-
-
-def test_merge():
-    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
-        with main('--merge') as bot:
-            assert bot.config.merge_opts != job.MergeJobOptions.default()
-            assert bot.config.merge_opts == job.MergeJobOptions.default(merge=True)
 
 
 # FIXME: I'd reallly prefer this to be a doctest, but adding --doctest-modules

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -165,6 +165,13 @@ def test_branch_regexp():
             assert bot.config.branch_regexp == re.compile('foo.*bar')
 
 
+def test_merge():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with main('--merge') as bot:
+            assert bot.config.merge_opts != job.MergeJobOptions.default()
+            assert bot.config.merge_opts == job.MergeJobOptions.default(merge=True)
+
+
 # FIXME: I'd reallly prefer this to be a doctest, but adding --doctest-modules
 # seems to seriously mess up the test run
 def test_time_interval():

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -44,6 +44,16 @@ class TestRepo(object):
             'git -C /tmp/local/path rev-parse HEAD'
         ]
 
+    def test_merge_success(self, mocked_run):
+        self.repo.merge('feature_branch', 'master_of_the_universe')
+
+        assert get_calls(mocked_run) == [
+            'git -C /tmp/local/path fetch origin',
+            'git -C /tmp/local/path checkout -B feature_branch origin/feature_branch --',
+            'git -C /tmp/local/path merge origin/master_of_the_universe',
+            'git -C /tmp/local/path rev-parse HEAD'
+        ]
+
     def test_reviewer_tagging_success(self, mocked_run):
         self.repo.tag_with_trailer(
             trailer_name='Reviewed-by',
@@ -86,6 +96,12 @@ class TestRepo(object):
     def test_rebase_same_branch(self, mocked_run):
         with pytest.raises(AssertionError):
             self.repo.rebase('branch', 'branch')
+
+        assert get_calls(mocked_run) == []
+
+    def test_merge_same_branch(self, mocked_run):
+        with pytest.raises(AssertionError):
+            self.repo.merge('branch', 'branch')
 
         assert get_calls(mocked_run) == []
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -407,7 +407,7 @@ class TestMergeJobOptions(object):
             reapprove=False,
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
-            merge=False,
+            use_merge_strategy=False,
         )
 
     def test_default_ci_time(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -407,6 +407,7 @@ class TestMergeJobOptions(object):
             reapprove=False,
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
+            merge=False,
         )
 
     def test_default_ci_time(self):


### PR DESCRIPTION
Fixes #72.

Adds a `--use-merge-strategy` option. It will cause marge to use `git merge` instead of `git rebase` when updating the merge request branch. This option conflicts with `--add-tested`.

I struggled a bit trying to find correct generic terms englobing both merge and rebase. Depending on the context I used update and fuse. There may be better ones.