### PR TITLE
Prune stale branches when fetching from remote

### DIFF
--- a/marge/git.py
+++ b/marge/git.py
@@ -84,7 +84,7 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout')):
     def _fuse_branch(self, strategy, branch, target_branch, source_repo_url=None):
         assert source_repo_url or branch != target_branch, branch
 
-        self.git('fetch', 'origin')
+        self.git('fetch', '--prune', 'origin')
         if source_repo_url:
             # "upsert" remote 'source' and fetch it
             try:
@@ -92,7 +92,7 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout')):
             except GitError:
                 pass
             self.git('remote', 'add', 'source', source_repo_url)
-            self.git('fetch', 'source')
+            self.git('fetch', '--prune', 'source')
             self.git('checkout', '-B', branch, 'source/' + branch, '--')
         else:
             self.git('checkout', '-B', branch, 'origin/' + branch, '--')

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -38,7 +38,7 @@ class TestRepo(object):
         self.repo.rebase('feature_branch', 'master_of_the_universe')
 
         assert get_calls(mocked_run) == [
-            'git -C /tmp/local/path fetch origin',
+            'git -C /tmp/local/path fetch --prune origin',
             'git -C /tmp/local/path checkout -B feature_branch origin/feature_branch --',
             'git -C /tmp/local/path rebase origin/master_of_the_universe',
             'git -C /tmp/local/path rev-parse HEAD'
@@ -48,7 +48,7 @@ class TestRepo(object):
         self.repo.merge('feature_branch', 'master_of_the_universe')
 
         assert get_calls(mocked_run) == [
-            'git -C /tmp/local/path fetch origin',
+            'git -C /tmp/local/path fetch --prune origin',
             'git -C /tmp/local/path checkout -B feature_branch origin/feature_branch --',
             'git -C /tmp/local/path merge origin/master_of_the_universe',
             'git -C /tmp/local/path rev-parse HEAD'


### PR DESCRIPTION
Fixes occasional error where local refs conflict with changes on the
remote:

    error: some local refs could not be updated; try running
    'git remote prune origin' to remove any old, conflicting branches