### PR TITLE
Wait for approvals race

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -129,6 +129,17 @@ def _parse_config(args):
         help='Marge-bot pushes effectively don\'t change approval status.\n',
     )
     parser.add_argument(
+        '--approval-reset-timeout',
+        type=time_interval,
+        default='0s',
+        help=(
+            'How long to wait for approvals to reset after pushing.\n'
+            'Only useful with the "new commits remove all approvals" option in a project\'s settings.\n'
+            'This is to handle the potential race condition where approvals don\'t reset in GitLab\n'
+            'after a force push due to slow processing of the event.\n'
+        ),
+    )
+    parser.add_argument(
         '--project-regexp',
         type=regexp,
         default='.*',
@@ -223,6 +234,7 @@ def main(args=None):
                 add_part_of=options.add_part_of,
                 add_reviewers=options.add_reviewers,
                 reapprove=options.impersonate_approvers,
+                approval_timeout=options.approval_reset_timeout,
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
                 use_merge_strategy=options.use_merge_strategy,

--- a/marge/job.py
+++ b/marge/job.py
@@ -130,9 +130,7 @@ class MergeJob(object):
             if sha_now != actual_sha:
                 raise CannotMerge('Someone pushed to branch while we were trying to merge')
             # Re-approve the merge request, in case us pushing it has removed
-            # approvals. Note that there is a bit of a race; effectively
-            # approval can't be withdrawn after we've pushed (resetting
-            # approvals)
+            # approvals.
             if self.opts.reapprove:
                 # approving is not idempotent, so we need to check first that there are no approvals,
                 # otherwise we'll get a failure on trying to re-instate the previous approvals

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -154,6 +154,15 @@ def test_impersonate_approvers():
             assert bot.config.merge_opts == job.MergeJobOptions.default(reapprove=True)
 
 
+def test_approval_reset_timeout():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with main('--approval-reset-timeout 1m') as bot:
+            assert bot.config.merge_opts != job.MergeJobOptions.default()
+            assert bot.config.merge_opts == job.MergeJobOptions.default(
+                approval_timeout=datetime.timedelta(seconds=60),
+            )
+
+
 def test_project_regexp():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with main("--project-regexp='foo.*bar'") as bot:


### PR DESCRIPTION
Add option to wait for approvals to reset after pushing.

When using the "new commits remove all approvals" option in a project's settings, it is possible to run into a race condition post-rebase where the approvals haven't reset by the time we check. This results in the later attempt to merge reporting that there are not enough approvals.