### PR TITLE
Fix Python 3 encoding issue on Windows

### DIFF
--- a/marge/git.py
+++ b/marge/git.py
@@ -1,6 +1,7 @@
 import logging as log
 import shlex
 import os
+import sys
 import subprocess
 from subprocess import PIPE, TimeoutExpired
 
@@ -168,7 +169,8 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout')):
 
 
 def _run(*args, env=None, check=False, timeout=None):
-    with subprocess.Popen([a.encode('utf-8') for a in args], env=env, stdout=PIPE, stderr=PIPE) as process:
+    encoded_args = [a.encode('utf-8') for a in args] if sys.platform != 'win32' else args
+    with subprocess.Popen(encoded_args, env=env, stdout=PIPE, stderr=PIPE) as process:
         try:
             stdout, stderr = process.communicate(input, timeout=timeout)
         except TimeoutExpired:


### PR DESCRIPTION
This MR fixed exception when running marge-bot on Windows:
```
2018-02-27 22:05:54,045 INFO Running git clone --origin=origin git@gitlab.com:group/Project.git 'C:\Users\oredko\AppData\Local\Temp\tmpkimhsi82\tmpj21n0on9'
Traceback (most recent call last):
  File "marge.app", line 3, in <module>
    marge.app.main()
  File "C:\Development\Git\marge-bot\marge\app.py", line 233, in main
    marge_bot.start()
  File "C:\Development\Git\marge-bot\marge\bot.py", line 39, in start
    self._run(repo_manager)
  File "C:\Development\Git\marge-bot\marge\bot.py", line 57, in _run
    projects,
  File "C:\Development\Git\marge-bot\marge\bot.py", line 95, in _process_projects
    self._process_merge_requests(repo_manager, project, merge_requests)
  File "C:\Development\Git\marge-bot\marge\bot.py", line 125, in _process_merge_requests
    repo = repo_manager.repo_for_project(project)
  File "C:\Development\Git\marge-bot\marge\store.py", line 22, in repo_for_project
    repo.clone()
  File "C:\Development\Git\marge-bot\marge\git.py", line 35, in clone
    self.git('clone', '--origin=origin', self.remote_url, self.local_path, from_repo=False)
  File "C:\Development\Git\marge-bot\marge\git.py", line 163, in git
    return _run(*command, env=env, check=True, timeout=timeout_seconds)
  File "C:\Development\Git\marge-bot\marge\git.py", line 174, in _run
    with subprocess.Popen([a.encode('utf-8') for a in args], env=env, stdout=PIPE, stderr=PIPE) as process:
  File "C:\Users\oredko\AppData\Local\Programs\Python\Python36-32\lib\subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "C:\Users\oredko\AppData\Local\Programs\Python\Python36-32\lib\subprocess.py", line 971, in _execute_child
    args = list2cmdline(args)
  File "C:\Users\oredko\AppData\Local\Programs\Python\Python36-32\lib\subprocess.py", line 461, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: a bytes-like object is required, not 'str'
```