### PR TITLE
Get latest CI status of a commit filtered by branch

### DIFF
--- a/marge/pipeline.py
+++ b/marge/pipeline.py
@@ -1,0 +1,28 @@
+from . import gitlab
+
+
+GET = gitlab.GET
+
+
+class Pipeline(gitlab.Resource):
+
+    @classmethod
+    def pipelines_by_branch(cls, project_id, branch, api):
+        pipelines_info = api.call(GET(
+            '/projects/{project_id}/pipelines'.format(project_id=project_id),
+            {'ref': branch, 'order_by': 'id', 'sort': 'desc'},
+        ))
+
+        return [cls(api, pipeline_info) for pipeline_info in pipelines_info]
+
+    @property
+    def ref(self):
+        return self.info['ref']
+
+    @property
+    def sha(self):
+        return self.info['sha']
+
+    @property
+    def status(self):
+        return self.info['status']

--- a/tests/gitlab_api_mock.py
+++ b/tests/gitlab_api_mock.py
@@ -94,6 +94,16 @@ class Api(gitlab.Api):
         path = '/projects/{0.project_id}/merge_requests/{0.iid}/approvals'
         self.add_resource(path, info, sudo, from_state, to_state)
 
+    def add_pipelines(self, project_id, info, sudo=None, from_state=None, to_state=None):
+        self.add_transition(
+            GET(
+                '/projects/%s/pipelines' % project_id,
+                args={'ref': info['ref'], 'order_by': 'id', 'sort': 'desc'},
+            ),
+            Ok([info]),
+            sudo, from_state, to_state,
+        )
+
     def expected_note(self, merge_request, note, sudo=None, from_state=None, to_state=None):
         self.add_transition(
             POST(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock
+
+from marge.gitlab import Api, GET
+from marge.pipeline import Pipeline
+
+
+INFO = {
+    "id": 47,
+    "status": "pending",
+    "ref": "new-pipeline",
+    "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a"
+}
+
+
+# pylint: disable=attribute-defined-outside-init
+class TestPipeline(object):
+
+    def setup_method(self, _method):
+        self.api = Mock(Api)
+
+    def test_pipelines_by_branch(self):
+        api = self.api
+        pl1, pl2 = INFO, dict(INFO, id=48)
+        api.call = Mock(return_value=[pl1, pl2])
+
+        result = Pipeline.pipelines_by_branch(project_id=1234, branch=INFO['ref'], api=api)
+        api.call.assert_called_once_with(GET(
+            '/projects/1234/pipelines',
+            {'ref': INFO['ref'], 'order_by': 'id', 'sort': 'desc'},
+        ))
+        assert [pl.info for pl in result] == [pl1, pl2]
+
+    def test_properties(self):
+        pipeline = Pipeline(api=self.api, info=INFO)
+        assert pipeline.id == 47
+        assert pipeline.status == "pending"
+        assert pipeline.ref == "new-pipeline"
+        assert pipeline.sha == "a91957a858320c0e17f3a0eca7cfacbff50ea29a"


### PR DESCRIPTION
The current implementation fetches the latest CI status for a particular sha. While a relatively rare circumstance, it's possible that at the point Marge-bot picks up an MR, another developer may have branched from the same commit and pushed to the repository. This new pipeline would be detected by Marge-bot, which could then be cancelled, causing Marge-bot to drop the MR stating "CI cancelled", while the CI for the correct branch will have passed.

This MR changes the CI status check to use the pipelines API, in order to filter status by ref (branch).

Commit.fetch_by_id() is no longer used after this change, I wasn't entirely sure whether I should remove that as part of this, leave it for a follow-up, or for you to decide what to do with it.