### PR TITLE
Bug Fix: Invalid named argument to fuse() when using merge strategy

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -322,11 +322,7 @@ def update_from_target_branch_and_push(
     branch_updated = branch_rewritten = changes_pushed = False
     try:
         fuse = repo.merge if use_merge_strategy else repo.rebase
-        rewritten_sha = updated_sha = fuse(
-            branch=source_branch,
-            new_base=target_branch,
-            source_repo_url=source_repo_url
-        )
+        rewritten_sha = updated_sha = fuse(source_branch, target_branch, source_repo_url)
         branch_updated = True
         # The fuse above fetches origin again, so we are now safe to fetch
         # the sha from the remote target branch.


### PR DESCRIPTION
Hi, I just found out that my previous pull request #77 isn't working properly (the wording commit a00b781bf02f71e3ecf003cbe53bcf9104a8ff80 introduced a bug). The named arguments to fuse() are inconsistent (merge and rebase have different argument names).

I can't fathom how I managed to miss that but anyway, here's a fix. Please tell me if you'd rather keep using named arguments when calling fuse (we can make the arguments name consistent again or get rid of fuse and call merge or rebase directly with their respective arguments).