### PR TITLE
Remove bare asterisk syntax

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -284,7 +284,7 @@ def update_from_target_branch_and_push(
         reviewers=None,
         tested_by=None,
         part_of=None,
-        use_merge_strategy=False,
+        use_merge_strategy=False
 ):
     """Updates `target_branch` with commits from `source_branch`, optionally add trailers and push.
     The update strategy can either be rebase or merge. The default is rebase.


### PR DESCRIPTION
    Remove trailing comma in function arg list with bare asterisk
    
    In Python 3.x before 3.6, there is a bug:
    
    It allows a trailing comma after arg list:
    
        def f(a, b,):
            pass
    
    But raise invalid syntax error when you have bare asterisk arg:
    
        def f(*, a, b,)
            pass
    
    Once we make this change, marge-bot code is ok to run with other python
    3 versions.
    
    Refer to: https://bugs.python.org/issue9232
