### PR TITLE
Add create-pipeline and job-regexp options

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -170,6 +170,17 @@ def _parse_config(args):
         help='Only process MRs whose target branches match the given regular expression.\n',
     )
     parser.add_argument(
+        '--job-regexp',
+        type=regexp,
+        default='.*',
+        help='Require pipelines to have jobs matching the given regular expression.\n',
+    )
+    parser.add_argument(
+        '--create-pipeline',
+        action='store_true',
+        help='Create new pipeline if not up to date or not matching job-regexp.\n',
+    )
+    parser.add_argument(
         '--debug',
         action='store_true',
         help='Debug logging (includes all HTTP requests etc).\n',
@@ -238,6 +249,8 @@ def main(args=None):
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
                 use_merge_strategy=options.use_merge_strategy,
+                job_regexp=options.job_regexp,
+                create_pipeline=options.create_pipeline,
             )
         )
 

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -124,3 +124,15 @@ class MergeRequest(gitlab.Resource):
         approvals = Approvals(self.api, info)
         approvals.refetch_info()
         return approvals
+
+    def triggered(self, user_id):
+        if self._api.version().release >= (9, 2, 2):
+            notes_url = '/projects/{0.project_id}/merge_requests/{0.iid}/notes'.format(self)
+        else:
+            # GitLab botched the v4 api before 9.2.2
+            notes_url = '/projects/{0.project_id}/merge_requests/{0.id}/notes'.format(self)
+
+        comments = self._api.collect_all_pages(GET(notes_url))
+        message = 'I created a new pipeline for {sha}'.format(sha=self.sha)
+        my_comments = [c['body'] for c in comments if c['author']['id'] == user_id]
+        return any(message in c for c in my_comments)

--- a/marge/pipeline.py
+++ b/marge/pipeline.py
@@ -1,7 +1,7 @@
 from . import gitlab
 
 
-GET = gitlab.GET
+GET, POST = gitlab.GET, gitlab.POST
 
 
 class Pipeline(gitlab.Resource):
@@ -26,3 +26,24 @@ class Pipeline(gitlab.Resource):
     @property
     def status(self):
         return self.info['status']
+
+    @property
+    def id(self):
+        return self.info['id']
+
+    def get_jobs(self, project_id):
+        jobs_info = self._api.call(GET(
+            '/projects/{project_id}/pipelines/{pipeline_id}/jobs'.format(project_id=project_id, pipeline_id=self.id)
+        ))
+
+        return jobs_info
+
+    def create(self, project_id, branch):
+        try:
+            new_pipeline = self._api.call(POST(
+                '/projects/{project_id}/pipeline'.format(project_id=project_id), {'ref': branch}
+            ))
+        except:
+            new_pipeline = None
+
+        return new_pipeline


### PR DESCRIPTION
This addresses #107 

`create-pipeline`: If for some reason no valid pipeline is found for the MR (none exists, outdated, etc.), Marge will create a new one using the api. She will also leave a message, so she can know that she already created a pipeline and will not do it again and again. Default is false.

`job-regexp`: The CI may be configured to run different jobs depending on the branch name, or pipeline source (push, trigger, api...). Marge will check the jobs in the current pipeline against this regexp. If any job matches the regexp, it's considered good and the status is checked as usual. If none matches, it's not a valid pipeline and either the merge will fail or a new pipeline will be created (see `create-pipeline`).

If using both `create-pipeline` and `job-regexp`, make sure the important jobs are configured to run on `api` sources (see the `only` and `except` options of GitLab CI), so that the pipeline created by Marge will be valid.