### PR TITLE
Do not push to source repository if there was no change

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -255,7 +255,11 @@ class MergeJob(object):
                 raise CannotMerge('these changes already exist in branch `{}`'.format(target_branch))
             rewritten_sha = self.add_trailers(merge_request) or updated_sha
             branch_rewritten = True
-            source_sha = repo.get_commit_hash('source/' + source_branch)
+            if merge_request.source_project_id == self._project.id:
+                source_name = 'origin/'
+            else:
+                source_name = 'source/'
+            source_sha = repo.get_commit_hash(source_name + source_branch)
             if rewritten_sha != source_sha:
                 repo.push(source_branch, source_repo_url=source_repo_url, force=True)
             changes_pushed = True

--- a/marge/job.py
+++ b/marge/job.py
@@ -255,7 +255,9 @@ class MergeJob(object):
                 raise CannotMerge('these changes already exist in branch `{}`'.format(target_branch))
             rewritten_sha = self.add_trailers(merge_request) or updated_sha
             branch_rewritten = True
-            repo.push(source_branch, source_repo_url=source_repo_url, force=True)
+            source_sha = repo.get_commit_hash('source/' + source_branch)
+            if rewritten_sha != source_sha:
+                repo.push(source_branch, source_repo_url=source_repo_url, force=True)
             changes_pushed = True
         except git.GitError:
             if not branch_updated:


### PR DESCRIPTION
In the simplest case where the MR can be immediately merged, there's no need for Marge to push to the source repository. In the case of a MR originating from a fork, Marge could have no permission to push, and then the merge fails for no good reason.

Proper handling of MRs from forks will come in a different PR (#113), but this looks like a harmless change that could be accepted right away.