### PR TITLE
Add create-pipeline and job-regexp options

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -175,6 +175,17 @@ def _parse_config(args):
         help='Only process MRs whose target branches match the given regular expression.\n',
     )
     parser.add_argument(
+        '--job-regexp',
+        type=regexp,
+        default='.*',
+        help='Require pipelines to have jobs matching the given regular expression.\n',
+    )
+    parser.add_argument(
+        '--create-pipeline',
+        action='store_true',
+        help='Create new pipeline if not up to date or not matching job-regexp.\n',
+    )
+    parser.add_argument(
         '--debug',
         action='store_true',
         help='Debug logging (includes all HTTP requests etc).\n',
@@ -246,6 +257,8 @@ def main(args=None):
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
                 use_merge_strategy=options.use_merge_strategy,
+                job_regexp=options.job_regexp,
+                create_pipeline=options.create_pipeline,
             ),
             batch=options.batch,
         )

--- a/marge/gitlab.py
+++ b/marge/gitlab.py
@@ -10,7 +10,7 @@ class Api(object):
         self._auth_token = auth_token
         self._api_base_url = gitlab_url.rstrip('/') + '/api/v4'
 
-    def call(self, command, sudo=None):
+    def call(self, command, sudo=None, response_json=None):
         method = command.method
         url = self._api_base_url + command.endpoint
         headers = {'PRIVATE-TOKEN': self._auth_token}
@@ -20,6 +20,9 @@ class Api(object):
         response = method(url, headers=headers, **command.call_args)
         log.debug('RESPONSE CODE: %s', response.status_code)
         log.debug('RESPONSE BODY: %r', response.content)
+
+        if response_json is not None:
+            response_json.update(response.json())
 
         if response.status_code == 204:
             return True

--- a/marge/pipeline.py
+++ b/marge/pipeline.py
@@ -31,6 +31,18 @@ class Pipeline(gitlab.Resource):
 
         return [cls(api, pipeline_info, project_id) for pipeline_info in pipelines_info]
 
+    @classmethod
+    def create(cls, project_id, ref, api):
+        try:
+            pipeline_info = {}
+            api.call(POST(
+                '/projects/{project_id}/pipeline'.format(project_id=project_id), {'ref': ref}),
+                response_json=pipeline_info
+            )
+            return cls(api, pipeline_info, project_id)
+        except gitlab.ApiError:
+            return None
+
     @property
     def project_id(self):
         return self.info['project_id']
@@ -55,3 +67,10 @@ class Pipeline(gitlab.Resource):
         return self._api.call(POST(
             '/projects/{0.project_id}/pipelines/{0.id}/cancel'.format(self),
         ))
+
+    def get_jobs(self):
+        jobs_info = self._api.call(GET(
+            '/projects/{0.project_id}/pipelines/{0.id}/jobs'.format(self),
+        ))
+
+        return jobs_info

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -118,10 +118,10 @@ class SingleMergeJob(MergeJob):
                     log.info('Merge request is already merged, someone was faster!')
                     updated_into_up_to_date_target_branch = True
                 else:
-                    raise CannotMerge("Gitlab refused to merge this request and I don't know why!")
+                    raise CannotMerge("GitLab refused to merge this request and I don't know why!")
             except gitlab.ApiError:
                 log.exception('Unanticipated ApiError from GitLab on merge attempt')
-                raise CannotMerge('had some issue with GitLab, check my logs...')
+                raise CannotMerge('Had some issue with GitLab, check my logs...')
             else:
                 self.wait_for_branch_to_be_merged()
                 updated_into_up_to_date_target_branch = True
@@ -137,7 +137,7 @@ class SingleMergeJob(MergeJob):
             if merge_request.state == 'merged':
                 return  # success!
             if merge_request.state == 'closed':
-                raise CannotMerge('someone closed the merge request while merging!')
+                raise CannotMerge('Someone closed the merge request while merging!')
             assert merge_request.state in ('opened', 'reopened', 'locked'), merge_request.state
 
             log.info('Giving %s more secs for !%s to be merged...', waiting_time_in_secs, merge_request.iid)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,4 +1,5 @@
 # pylint: disable=protected-access
+import re
 from datetime import timedelta
 from unittest.mock import ANY, Mock, patch
 
@@ -42,7 +43,9 @@ class TestJob(object):
 
     def test_get_mr_ci_status(self):
         with patch('marge.job.Pipeline') as pipeline_class:
-            pipeline_class.pipelines_by_branch.return_value = [Mock(sha='abc', status='success')]
+            pipeline = Mock(sha='abc', status='success')
+            pipeline_class.pipelines_by_branch.return_value = [pipeline]
+            pipeline.get_jobs.return_value = [{'name': 'job1'}]
             merge_job = self.get_merge_job()
             merge_request = Mock(sha='abc')
 
@@ -176,6 +179,8 @@ class TestMergeJobOptions(object):
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
             use_merge_strategy=False,
+            job_regexp=re.compile('.*'),
+            create_pipeline=False,
         )
 
     def test_default_ci_time(self):

--- a/tests/test_single_job.py
+++ b/tests/test_single_job.py
@@ -32,6 +32,7 @@ def _pipeline(sha1, status):
         'status': status,
         'ref': 'useless_new_feature',
         'sha': sha1,
+        'jobs': [{'name': 'job1'}, {'name': 'job2'}],
     }
 
 
@@ -325,7 +326,7 @@ class TestUpdateAndAccept(object):
             Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
             from_state='passed', to_state='rejected_for_mysterious_reasons',
         )
-        message = "Gitlab refused to merge this request and I don't know why!"
+        message = "GitLab refused to merge this request and I don't know why!"
         with mocklab.branch_update(), mocklab.expected_failure(message):
             job = self.make_job()
             job.execute()
@@ -381,7 +382,7 @@ class TestUpdateAndAccept(object):
 
     def test_fails_if_changes_already_exist(self, unused_time_sleep):
         api, mocklab = self.api, self.mocklab
-        expected_message = 'these changes already exist in branch `{}`'.format(
+        expected_message = 'These changes already exist in branch `{}`.'.format(
             mocklab.merge_request_info['target_branch'],
         )
         with mocklab.expected_failure(expected_message):


### PR DESCRIPTION
This addresses #107, and replaces #109 (changing source branch)

`create-pipeline`: If for some reason no valid pipeline is found for the MR (none exists, outdated, etc.), Marge will create a new one using the api. She will also leave a message, so she can know that she already created a pipeline and will not do it again and again. Default is false.

`job-regexp`: The CI may be configured to run different jobs depending on the branch name, or pipeline source (push, trigger, api...). Marge will check the jobs in the current pipeline against this regexp. If any job matches the regexp, it's considered good and the status is checked as usual. If none matches, it's not a valid pipeline and either the merge will fail or a new pipeline will be created (see `create-pipeline`).

If using both `create-pipeline` and `job-regexp`, make sure the important jobs are configured to run on `api` sources (see the `only` and `except` options of GitLab CI), so that the pipeline created by Marge will be valid.