### PR TITLE
Ignore GitLab server errors when looking for projects and MRs

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -32,10 +32,13 @@ class MergeRequest(gitlab.Resource):
 
     @classmethod
     def fetch_all_open_for_user(cls, project_id, user_id, api):
-        all_merge_request_infos = api.collect_all_pages(GET(
-            '/projects/{project_id}/merge_requests'.format(project_id=project_id),
-            {'state': 'opened', 'order_by': 'created_at', 'sort': 'asc'},
-        ))
+        try:
+            all_merge_request_infos = api.collect_all_pages(GET(
+                '/projects/{project_id}/merge_requests'.format(project_id=project_id),
+                {'state': 'opened', 'order_by': 'created_at', 'sort': 'asc'},
+            ))
+        except gitlab.InternalServerError:
+            all_merge_request_infos = []
         my_merge_request_infos = [
             mri for mri in all_merge_request_infos
             if (mri['assignee'] or {}).get('id') == user_id

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -1,3 +1,4 @@
+import logging as log
 from . import gitlab
 from .approvals import Approvals
 
@@ -38,6 +39,7 @@ class MergeRequest(gitlab.Resource):
                 {'state': 'opened', 'order_by': 'created_at', 'sort': 'asc'},
             ))
         except gitlab.InternalServerError:
+            log.warning('Internal server error from GitLab! Ignoring...')
             all_merge_request_infos = []
         my_merge_request_infos = [
             mri for mri in all_merge_request_infos

--- a/marge/project.py
+++ b/marge/project.py
@@ -27,10 +27,13 @@ class Project(gitlab.Resource):
 
     @classmethod
     def fetch_all_mine(cls, api):
-        projects_info = api.collect_all_pages(GET(
-            '/projects',
-            {'membership': True, 'with_merge_requests_enabled': True},
-        ))
+        try:
+            projects_info = api.collect_all_pages(GET(
+                '/projects',
+                {'membership': True, 'with_merge_requests_enabled': True},
+            ))
+        except gitlab.InternalServerError:
+            projects_info = []
 
         def project_seems_ok(project_info):
             # A bug in at least GitLab 9.3.5 would make GitLab not report permissions after

--- a/marge/project.py
+++ b/marge/project.py
@@ -33,6 +33,7 @@ class Project(gitlab.Resource):
                 {'membership': True, 'with_merge_requests_enabled': True},
             ))
         except gitlab.InternalServerError:
+            log.warning('Internal server error from GitLab! Ignoring...')
             projects_info = []
 
         def project_seems_ok(project_info):


### PR DESCRIPTION
It is not uncommon for GitLab to have temporary errors (500 responses or other). If this happens while processing a MR, the safe thing is probably to abort. But if it happens while looking for projects or MRs, it should be OK to just ignore the error and proceed with an empty list (i.e., wait and rerun the loop).