### PR TITLE
Check MR is mergeable before accepting MR

### DIFF
--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -68,6 +68,9 @@ class SingleMergeJob(MergeJob):
             if source_project.only_allow_merge_if_pipeline_succeeds:
                 self.wait_for_ci_to_pass(merge_request, actual_sha)
                 time.sleep(2)
+
+            self.ensure_mergeable_mr(merge_request)
+
             try:
                 merge_request.accept(remove_branch=True, sha=actual_sha)
             except gitlab.NotAcceptable as err:


### PR DESCRIPTION
It's useful to check that we are still able to merge the MR after it has
finished CI. Whilst we can check the error message afterwards, these are
not always clearer and we'd essentially be doing the same checks as
these anyway.

As an extra advantage, we also refuse to merge if someone has since
unassigned from Marge (something that people tend to do without
realising it has no effect after Marge has run it's preflight checks).