### PR TITLE
[BUGFIX] Force pushing do not work with protected branches

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -255,7 +255,7 @@ class MergeJob(object):
                 raise CannotMerge('these changes already exist in branch `{}`'.format(target_branch))
             rewritten_sha = self.add_trailers(merge_request) or updated_sha
             branch_rewritten = True
-            repo.push(source_branch, source_repo_url=source_repo_url, force=True)
+            repo.push(source_branch, source_repo_url=source_repo_url, force=False)
             changes_pushed = True
         except git.GitError:
             if not branch_updated:


### PR DESCRIPTION
Error: "I couldn't merge this branch: failed to push merged changes, check my logs!"

`GitLab: You are not allowed to force push code to a protected branch on this project.`

As mentioned here: https://about.gitlab.com/2014/11/26/keeping-your-code-protected/

`Note that even Maintainer is not able to force push to or delete a protected branch.`