### PR TITLE
Allow reference repository in git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ optional arguments:
   --git-timeout GIT_TIMEOUT
                         How long a single git operation can take.
                            [env var: MARGE_GIT_TIMEOUT] (default: 120s)
+  --git-reference-repo GIT_REFERENCE_REPO
+                        A reference repo to be used when git cloning.
+                           [env var: MARGE_GIT_REFERENCE_REPO] (default: None)
   --branch-regexp BRANCH_REGEXP
                         Only process MRs whose target branches match the given regular expression.
                            [env var: MARGE_BRANCH_REGEXP] (default: .*)

--- a/README.md
+++ b/README.md
@@ -77,11 +77,15 @@ optional arguments:
   --embargo INTERVAL[,..]
                         Time(s) during which no merging is to take place, e.g. "Friday 1pm - Monday 9am".
                            [env var: MARGE_EMBARGO] (default: None)
-  --use-merge-strategy  Use git merge instead of git rebase (EXPERIMENTAL)
-                        Enable if you use a workflow based on merge-commits and not linear history.
+  --use-merge-strategy  Use git merge instead of git rebase to update the *source* branch (EXPERIMENTAL)
+                        If you need to use a strict no-rebase workflow (in most cases
+                        you don't want this, even if you configured gitlab to use merge requests
+                        to use merge commits on the *target* branch (the default).)
                            [env var: MARGE_USE_MERGE_STRATEGY] (default: False)
   --add-tested          Add "Tested: marge-bot <$MR_URL>" for the final commit on branch after it passed CI.
                            [env var: MARGE_ADD_TESTED] (default: False)
+  --batch               Enable processing MRs in batches
+                           [env var: MARGE_BATCH] (default: False)
   --add-part-of         Add "Part-of: <$MR_URL>" to each commit in MR.
                            [env var: MARGE_ADD_PART_OF] (default: False)
   --add-reviewers       Add "Reviewed-by: $approver" for each approver of MR to each commit in MR.
@@ -94,6 +98,7 @@ optional arguments:
                         Only useful with the "new commits remove all approvals" option in a project's settings.
                         This is to handle the potential race condition where approvals don't reset in GitLab
                         after a force push due to slow processing of the event.
+                           [env var: MARGE_APPROVAL_RESET_TIMEOUT] (default: 0s)
   --project-regexp PROJECT_REGEXP
                         Only process projects that match; e.g. 'some_group/.*' or '(?!exclude/me)'.
                            [env var: MARGE_PROJECT_REGEXP] (default: .*)
@@ -114,8 +119,6 @@ optional arguments:
                            [env var: MARGE_BRANCH_REGEXP] (default: .*)
   --debug               Debug logging (includes all HTTP requests etc).
                            [env var: MARGE_DEBUG] (default: False)
-  --batch               Enable processing MRs in batches.
-                           [env var: MARGE_BATCH] (default: False)
 ```
 Here is a config file example
 ```yaml

--- a/marge/app.py
+++ b/marge/app.py
@@ -107,7 +107,7 @@ def _parse_config(args):
             'Use git merge instead of git rebase to update the *source* branch (EXPERIMENTAL)\n'
             'If you need to use a strict no-rebase workflow (in most cases\n'
             'you don\'t want this, even if you configured gitlab to use merge requests\n'
-            'to use merge commits on the *target* branch (the default).)'
+            'to use merge commits on the *target* branch (the default).)\n'
         ),
     )
     parser.add_argument(

--- a/marge/app.py
+++ b/marge/app.py
@@ -171,6 +171,12 @@ def _parse_config(args):
         help='How long a single git operation can take.\n'
     )
     parser.add_argument(
+        '--git-reference-repo',
+        type=str,
+        default=None,
+        help='A reference repo to be used when git cloning.\n'
+    )
+    parser.add_argument(
         '--branch-regexp',
         type=regexp,
         default='.*',
@@ -243,6 +249,7 @@ def main(args=None):
             ssh_key_file=ssh_key_file,
             project_regexp=options.project_regexp,
             git_timeout=options.git_timeout,
+            git_reference_repo=options.git_reference_repo,
             branch_regexp=options.branch_regexp,
             merge_opts=bot.MergeJobOptions.default(
                 add_tested=options.add_tested,

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -37,6 +37,7 @@ class Bot(object):
                 root_dir=root_dir,
                 ssh_key_file=self._config.ssh_key_file,
                 timeout=self._config.git_timeout,
+                reference=self._config.git_reference_repo,
             )
             self._run(repo_manager)
 
@@ -165,7 +166,8 @@ class Bot(object):
 
 
 class BotConfig(namedtuple('BotConfig',
-                           'user ssh_key_file project_regexp merge_opts git_timeout branch_regexp batch')):
+                           'user ssh_key_file project_regexp merge_opts git_timeout ' +
+                           'git_reference_repo branch_regexp batch')):
     pass
 
 

--- a/marge/git.py
+++ b/marge/git.py
@@ -30,9 +30,11 @@ def _filter_branch_script(trailer_name, trailer_values):
     return filter_script
 
 
-class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout')):
+class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout reference')):
     def clone(self):
-        self.git('clone', '--origin=origin', self.remote_url, self.local_path, from_repo=False)
+        reference_flag = '--reference=' + self.reference if self.reference else ''
+        self.git('clone', '--origin=origin', reference_flag, self.remote_url,
+                 self.local_path, from_repo=False)
 
     def config_user_info(self, user_name, user_email):
         self.git('config', 'user.email', user_email)

--- a/marge/store.py
+++ b/marge/store.py
@@ -5,12 +5,13 @@ from . import git
 
 class RepoManager(object):
 
-    def __init__(self, user, root_dir, ssh_key_file=None, timeout=None):
+    def __init__(self, user, root_dir, ssh_key_file=None, timeout=None, reference=None):
         self._root_dir = root_dir
         self._user = user
         self._ssh_key_file = ssh_key_file
         self._repos = {}
         self._timeout = timeout
+        self._reference = reference
 
     def repo_for_project(self, project):
         repo = self._repos.get(project.id)
@@ -18,7 +19,8 @@ class RepoManager(object):
             repo_url = project.ssh_url_to_repo
             local_repo_dir = tempfile.mkdtemp(dir=self._root_dir)
 
-            repo = git.Repo(repo_url, local_repo_dir, ssh_key_file=self._ssh_key_file, timeout=self._timeout)
+            repo = git.Repo(repo_url, local_repo_dir, ssh_key_file=self._ssh_key_file,
+                            timeout=self._timeout, reference=self._reference)
             repo.clone()
             repo.config_user_info(
                 user_email=self._user.email,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -199,6 +199,12 @@ def test_branch_regexp():
             assert bot.config.branch_regexp == re.compile('foo.*bar')
 
 
+def test_git_reference_repo():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with main("--git-reference-repo='/foo/reference_repo'") as bot:
+            assert bot.config.git_reference_repo == '/foo/reference_repo'
+
+
 # FIXME: I'd reallly prefer this to be a doctest, but adding --doctest-modules
 # seems to seriously mess up the test run
 def test_time_interval():

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -21,6 +21,7 @@ class TestRepo(object):
             local_path='/tmp/local/path',
             ssh_key_file=None,
             timeout=datetime.timedelta(seconds=1),
+            reference=None,
         )
 
     def test_clone(self, mocked_run):
@@ -189,6 +190,14 @@ class TestRepo(object):
         assert get_calls(mocked_run) == [
             '%s git -C /tmp/local/path config user.email bart@gmail.com' % git_ssh,
             '%s git -C /tmp/local/path config user.name bart' % git_ssh,
+        ]
+
+    def test_passes_reference_repo(self, mocked_run):
+        repo = self.repo._replace(reference='/foo/reference_repo')
+        repo.clone()
+        assert get_calls(mocked_run) == [
+            'git clone --origin=origin --reference=/foo/reference_repo ssh://git@git.foo.com/some/repo.git ' +
+            '/tmp/local/path',
         ]
 
 


### PR DESCRIPTION
Adds a new command line argument: --git-reference-repo

Specify a local copy of the git repo to speed up git clone times and
minimize load on the remote side. This is useful with large
repositories.