### PR TITLE
Job invocation isolated in a method

### DIFF
--- a/marge/bot.py
+++ b/marge/bot.py
@@ -153,7 +153,14 @@ class Bot(object):
                 log.exception('BatchMergeJob failed: %s', err)
         log.info('Attempting to merge the oldest MR...')
         merge_request = merge_requests[0]
-        merge_job = single_merge_job.SingleMergeJob(
+        merge_job = self._get_job(
+            project=project, merge_request=merge_request, repo=repo,
+            options=self._config.merge_opts,
+        )
+        merge_job.execute()
+
+    def _get_job(self, project, merge_request, repo, options):
+        return single_merge_job.SingleMergeJob(
             api=self._api,
             user=self.user,
             project=project,
@@ -161,7 +168,6 @@ class Bot(object):
             repo=repo,
             options=self._config.merge_opts,
         )
-        merge_job.execute()
 
 
 class BotConfig(namedtuple('BotConfig',

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -153,20 +153,20 @@ class Bot(object):
                 log.exception('BatchMergeJob failed: %s', err)
         log.info('Attempting to merge the oldest MR...')
         merge_request = merge_requests[0]
-        merge_job = self._get_job(
+        merge_job = self._get_single_job(
             project=project, merge_request=merge_request, repo=repo,
             options=self._config.merge_opts,
         )
         merge_job.execute()
 
-    def _get_job(self, project, merge_request, repo, options):
+    def _get_single_job(self, project, merge_request, repo, options):
         return single_merge_job.SingleMergeJob(
             api=self._api,
             user=self.user,
             project=project,
             merge_request=merge_request,
             repo=repo,
-            options=self._config.merge_opts,
+            options=options,
         )
 
 


### PR DESCRIPTION
In order to enable bot derived class to launch different kind of jobs.
For example I createsd a derived Bot class that manages Rebase jobs : that new bot can overload the _get_job method in order to launch the proper job (Rebase)