### PR TITLE
Fetch pipeline with SHA matching commit SHA

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -121,9 +121,9 @@ class MergeJob(object):
             merge_request.source_branch,
             self._api,
         )
-        current_pipeline = next(iter(pipelines), None)
+        current_pipeline = next(iter(pipeline for pipeline in pipelines if pipeline.sha == commit_sha), None)
 
-        if current_pipeline and current_pipeline.sha == commit_sha:
+        if current_pipeline:
             ci_status = current_pipeline.status
         else:
             log.warning('No pipeline listed for %s on branch %s', commit_sha, merge_request.source_branch)


### PR DESCRIPTION
We currently just fetch the first pipeline. Whilst this is ordered by
ID, technically this doesn't guarantee that the pipeline will be for the
SHA we're looking for. To handle this, we can explicitly fetch the
pipeline for the SHA we want.

Closes: #134.