### PR TITLE
Add appropriate error if unresolved discussions on merge request

### DIFF
--- a/marge/project.py
+++ b/marge/project.py
@@ -62,6 +62,10 @@ class Project(gitlab.Resource):
         return self.info['only_allow_merge_if_pipeline_succeeds']
 
     @property
+    def only_allow_merge_if_all_discussions_are_resolved(self):  # pylint: disable=invalid-name
+        return self.info['only_allow_merge_if_all_discussions_are_resolved']
+
+    @property
     def approvals_required(self):
         return self.info['approvals_before_merge']
 

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -121,7 +121,12 @@ class SingleMergeJob(MergeJob):
                     log.info('Merge request is already merged, someone was faster!')
                     updated_into_up_to_date_target_branch = True
                 else:
-                    raise CannotMerge("Gitlab refused to merge this request and I don't know why!")
+                    raise CannotMerge(
+                        "Gitlab refused to merge this request and I don't know why!" + (
+                            " Maybe you have unresolved discussions?"
+                            if self._project.only_allow_merge_if_all_discussions_are_resolved else ""
+                        )
+                    )
             except gitlab.ApiError:
                 log.exception('Unanticipated ApiError from GitLab on merge attempt')
                 raise CannotMerge('had some issue with GitLab, check my logs...')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -11,6 +11,7 @@ INFO = {
     'ssh_url_to_repo': 'ssh://blah.com/cool/project.git',
     'merge_requests_enabled': True,
     'only_allow_merge_if_pipeline_succeeds': True,
+    'only_allow_merge_if_all_discussions_are_resolved': False,
     'permissions': {
         'project_access': {
             'access_level': AccessLevel.developer.value,
@@ -81,6 +82,7 @@ class TestProject(object):
         assert project.ssh_url_to_repo == 'ssh://blah.com/cool/project.git'
         assert project.merge_requests_enabled is True
         assert project.only_allow_merge_if_pipeline_succeeds is True
+        assert project.only_allow_merge_if_all_discussions_are_resolved is False
         assert project.access_level == AccessLevel.developer
 
     def test_group_access(self):


### PR DESCRIPTION
Note that this doesn't use the discussions API, as it's a rather
convoluted process that doesn't work entirely as expected (the resolved
field doesn't appear to exist, for instance). Instead, we just check if
this setting is enabled at the project level, and if we haven't assumed
it's a different error then this is the most likely cause.

Closes: #64 