### PR TITLE
Ensure reviewer and commit author aren't the same

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -147,3 +147,6 @@ class MergeRequest(gitlab.Resource):
         approvals = Approvals(self.api, info)
         approvals.refetch_info()
         return approvals
+
+    def fetch_commits(self):
+        return self._api.call(GET('/projects/{0.project_id}/merge_requests/{0.iid}/commits'.format(self)))


### PR DESCRIPTION
Check all approvers against all commit authors, and ensure a commit
author hasn't approved their own MR.

Closes: #15 