### PR TITLE
add rebase-then-merge strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ ENV/
 .cache
 *.egg-info
 .coverage
+*.swp
+*.swo
 
 # nix stuff
 result

--- a/marge/gitlab.py
+++ b/marge/gitlab.py
@@ -16,7 +16,11 @@ class Api(object):
         headers = {'PRIVATE-TOKEN': self._auth_token}
         if sudo:
             headers['SUDO'] = '%d' % sudo
-        log.debug('REQUEST: %s %s %r %r', method.__name__.upper(), url, headers, command.call_args)
+        cleaned_headers = headers.copy()
+        cleaned_headers['PRIVATE-TOKEN'] = 'xxxx'
+        log.debug(
+            'REQUEST: %s %s %r %r',
+            method.__name__.upper(), url, cleaned_headers, command.call_args)
         response = method(url, headers=headers, **command.call_args)
         log.debug('RESPONSE CODE: %s', response.status_code)
         log.debug('RESPONSE BODY: %r', response.content)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -102,11 +102,13 @@ def test_embargo():
             )
 
 
-def test_use_merge_strategy():
+def test_merge_strategy():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with main('--use-merge-strategy') as bot:
             assert bot.config.merge_opts != job.MergeJobOptions.default()
-            assert bot.config.merge_opts == job.MergeJobOptions.default(use_merge_strategy=True)
+            assert bot.config.merge_opts.merge_strategy == job.MergeStrategy.merge
+        with main('--merge-strategy=rebase') as bot:
+            assert bot.config.merge_opts.merge_strategy == job.MergeStrategy.rebase
 
 
 def test_add_tested():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, Mock, patch, create_autospec
 
 import pytest
 
-from marge.job import CannotMerge, MergeJob, MergeJobOptions, SkipMerge
+from marge.job import CannotMerge, MergeJob, MergeJobOptions, SkipMerge, MergeStrategy
 import marge.interval
 import marge.git
 import marge.gitlab
@@ -147,7 +147,8 @@ class TestJob(object):
         merge_request.unassign.assert_called_once()
 
     def test_fuse_using_rebase(self):
-        merge_job = self.get_merge_job(options=MergeJobOptions.default(use_merge_strategy=False))
+        merge_job = self.get_merge_job(
+            options=MergeJobOptions.default(merge_strategy=MergeStrategy.rebase))
         branch_a = 'A'
         branch_b = 'B'
 
@@ -161,7 +162,8 @@ class TestJob(object):
         )
 
     def test_fuse_using_merge(self):
-        merge_job = self.get_merge_job(options=MergeJobOptions.default(use_merge_strategy=True))
+        merge_job = self.get_merge_job(
+            options=MergeJobOptions.default(merge_strategy=MergeStrategy.merge))
         branch_a = 'A'
         branch_b = 'B'
 
@@ -185,7 +187,7 @@ class TestMergeJobOptions(object):
             approval_timeout=timedelta(seconds=0),
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
-            use_merge_strategy=False,
+            merge_strategy=MergeStrategy.rebase,
         )
 
     def test_default_ci_time(self):


### PR DESCRIPTION
This implements #140 by generalizing the --use-merge-strategy to --merge-strategy={merge,rebase,rebase_then_merge}.  Rationale is in #140.

I did some hand testing and it seems to work, but nothing really exhaustive.

There are also a few unrelated commits in there, but hopefully they're not controversial.