### PR TITLE
Push a master-tagged image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ services:
 language: nix
 deploy:
   provider: script
-  script: make dockerize && make docker-push
+  script: make dockerize && make docker-push VERSION="$TRAVIS_BRANCH"
   on:
     repo: smarkets/marge-bot
-    tags: true
-    condition: "$TRAVIS_TAG = $(cat version)"
+    all_branches: true
+    condition: "$TRAVIS_BRANCH = $(cat version) || $TRAVIS_BRANCH = master"
 env:
   global:
     # smarkets ci docker username

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION?=$$(git rev-parse --abbrev-ref HEAD)
+
 requirements_frozen.txt requirements.nix requirements_override.nix: requirements.txt
 	pypi2nix -V 3.6 -r $^
 
@@ -25,10 +27,11 @@ docker-push:
 	  docker login; \
 	fi
 	docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:latest
-	docker push smarkets/marge-bot:$$(cat version)
+	docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:$(VERSION)
+	docker push smarkets/marge-bot:$(VERSION)
 	docker push smarkets/marge-bot:latest
 	# for backwards compatibility push to previous location
 	docker tag smarkets/marge-bot:latest smarketshq/marge-bot:latest
-	docker tag smarkets/marge-bot:latest smarketshq/marge-bot:$$(cat version)
-	docker push smarketshq/marge-bot:$$(cat version)
+	docker tag smarkets/marge-bot:latest smarketshq/marge-bot:$(VERSION)
+	docker push smarketshq/marge-bot:$(VERSION)
 	docker push smarketshq/marge-bot:latest

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ docker-push:
 	fi
 	docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:latest
 	docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:$(VERSION)
+	if [ "$(VERSION)" = "$$(cat version)" ]; then \
+	  docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:stable; \
+	  docker push smarkets/marge-bot:stable; \
+	fi
 	docker push smarkets/marge-bot:$(VERSION)
 	docker push smarkets/marge-bot:latest
 	# for backwards compatibility push to previous location

--- a/Makefile
+++ b/Makefile
@@ -26,16 +26,16 @@ docker-push:
 	else \
 	  docker login; \
 	fi
-	docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:latest
 	docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:$(VERSION)
 	if [ "$(VERSION)" = "$$(cat version)" ]; then \
+	  docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:latest
 	  docker tag smarkets/marge-bot:$$(cat version) smarkets/marge-bot:stable; \
 	  docker push smarkets/marge-bot:stable; \
+	  docker push smarkets/marge-bot:latest; \
 	fi
 	docker push smarkets/marge-bot:$(VERSION)
-	docker push smarkets/marge-bot:latest
 	# for backwards compatibility push to previous location
-	docker tag smarkets/marge-bot:latest smarketshq/marge-bot:latest
-	docker tag smarkets/marge-bot:latest smarketshq/marge-bot:$(VERSION)
+	docker tag smarkets/marge-bot:$$(cat version) smarketshq/marge-bot:latest
+	docker tag smarkets/marge-bot:$$(cat version) smarketshq/marge-bot:$(VERSION)
 	docker push smarketshq/marge-bot:$(VERSION)
 	docker push smarketshq/marge-bot:latest

--- a/README.md
+++ b/README.md
@@ -226,15 +226,15 @@ ssh-key: |
 ```bash
 docker run --restart=on-failure \
   -v "$(pwd)":/configuration \
-  smarkets/marge-bot:stable \
+  smarkets/marge-bot \
   --config-file=/configuration/marge-bot-config.yaml
 ```
 
-Note the use of the stable tag, which will use the latest released version.
-Without this, by default docker will use the `latest` tag, which corresponds to
-the HEAD commit of the `master` branch. Feel free to use this instead (or the
-`master` tag, to be more precise) if you want the latest updates, at the risk
-of possible bugs.
+By default docker will use the `latest` tag, which corresponds to the latest 
+stable version. You can also use the `stable` tag to make this more explicit.
+If you want a development version, you can use the `master` tag to obtain an
+image built from the HEAD commit of the `master` branch. Note that this image
+may contain bugs.
 
 You can also specify a particular version as a tag, e.g.
 `smarkets/marge-bot:0.7.0`.

--- a/README.md
+++ b/README.md
@@ -226,9 +226,18 @@ ssh-key: |
 ```bash
 docker run --restart=on-failure \
   -v "$(pwd)":/configuration \
-  smarkets/marge-bot \
+  smarkets/marge-bot:stable \
   --config-file=/configuration/marge-bot-config.yaml
 ```
+
+Note the use of the stable tag, which will use the latest released version.
+Without this, by default docker will use the `latest` tag, which corresponds to
+the HEAD commit of the `master` branch. Feel free to use this instead (or the
+`master` tag, to be more precise) if you want the latest updates, at the risk
+of possible bugs.
+
+You can also specify a particular version as a tag, e.g.
+`smarkets/marge-bot:0.7.0`.
 
 ### Running marge-bot in kubernetes
 It's also possible to run marge in kubernetes, e.g. here's how you use a ktmpl


### PR DESCRIPTION
Push a new docker image with tag "master" for every new build on the
master branch. This gives users wishing to run with the latest
development changes an easy way to stay up to date.

Note: when a tag is created, Travis sets the $TRAVIS_BRANCH envvar to
the tag, rather than the branch, hence why we only use this variable
now.

Closes: #139.