### PR TITLE
Add an option to merge requests in order of oldest update time

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ optional arguments:
   --impersonate-approvers
                         Marge-bot pushes effectively don't change approval status.
                            [env var: MARGE_IMPERSONATE_APPROVERS] (default: False)
+  --merge-order         The order you want marge to merge its requests.
+                        As of earliest merge request creation time (created_at) or update time (updated_at)
+                          [env var: MARGE_MERGE_ORDER] (default: created_at)
   --approval-reset-timeout APPROVAL_RESET_TIMEOUT
                         How long to wait for approvals to reset after pushing.
                         Only useful with the "new commits remove all approvals" option in a project's settings.

--- a/marge/app.py
+++ b/marge/app.py
@@ -136,6 +136,12 @@ def _parse_config(args):
         help='Marge-bot pushes effectively don\'t change approval status.\n',
     )
     parser.add_argument(
+        '--merge-order',
+        default='created_at',
+        choices=('created_at', 'updated_at'),
+        help='Order marge merges assigned requests. created_at (default) or updated_at.\n',
+    )
+    parser.add_argument(
         '--approval-reset-timeout',
         type=time_interval,
         default='0s',
@@ -251,6 +257,7 @@ def main(args=None):
             git_timeout=options.git_timeout,
             git_reference_repo=options.git_reference_repo,
             branch_regexp=options.branch_regexp,
+            merge_order=options.merge_order,
             merge_opts=bot.MergeJobOptions.default(
                 add_tested=options.add_tested,
                 add_part_of=options.add_part_of,

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -103,7 +103,8 @@ class Bot(object):
         my_merge_requests = MergeRequest.fetch_all_open_for_user(
             project_id=project.id,
             user_id=self.user.id,
-            api=self._api
+            api=self._api,
+            merge_order=self._config.merge_order,
         )
         branch_regexp = self._config.branch_regexp
         filtered_mrs = [mr for mr in my_merge_requests
@@ -172,7 +173,7 @@ class Bot(object):
 
 
 class BotConfig(namedtuple('BotConfig',
-                           'user ssh_key_file project_regexp merge_opts git_timeout ' +
+                           'user ssh_key_file project_regexp merge_order merge_opts git_timeout ' +
                            'git_reference_repo branch_regexp batch')):
     pass
 

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -31,10 +31,10 @@ class MergeRequest(gitlab.Resource):
         return merge_request
 
     @classmethod
-    def fetch_all_open_for_user(cls, project_id, user_id, api):
+    def fetch_all_open_for_user(cls, project_id, user_id, api, merge_order):
         all_merge_request_infos = api.collect_all_pages(GET(
             '/projects/{project_id}/merge_requests'.format(project_id=project_id),
-            {'state': 'opened', 'order_by': 'created_at', 'sort': 'asc'},
+            {'state': 'opened', 'order_by': merge_order, 'sort': 'asc'},
         ))
         my_merge_request_infos = [
             mri for mri in all_merge_request_infos

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -92,6 +92,7 @@ def test_default_values():
             assert bot.config.project_regexp == re.compile('.*')
             assert bot.config.git_timeout == datetime.timedelta(seconds=120)
             assert bot.config.merge_opts == job.MergeJobOptions.default()
+            assert bot.config.merge_order == 'created_at'
 
 
 def test_embargo():
@@ -203,6 +204,12 @@ def test_git_reference_repo():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with main("--git-reference-repo='/foo/reference_repo'") as bot:
             assert bot.config.git_reference_repo == '/foo/reference_repo'
+
+
+def test_merge_order():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with main("--merge-order='updated_at'") as bot:
+            assert bot.config.merge_order == 'updated_at'
 
 
 # FIXME: I'd reallly prefer this to be a doctest, but adding --doctest-modules

--- a/tests/test_merge_request.py
+++ b/tests/test_merge_request.py
@@ -111,7 +111,9 @@ class TestMergeRequest(object):
         api = self.api
         mr1, mr_not_me, mr2 = INFO, dict(INFO, assignee={'id': _MARGE_ID+1}, id=679), dict(INFO, id=678)
         api.collect_all_pages = Mock(return_value=[mr1, mr_not_me, mr2])
-        result = MergeRequest.fetch_all_open_for_user(1234, user_id=_MARGE_ID, api=api)
+        result = MergeRequest.fetch_all_open_for_user(
+            1234, user_id=_MARGE_ID, api=api, merge_order='created_at'
+        )
         api.collect_all_pages.assert_called_once_with(GET(
             '/projects/1234/merge_requests',
             {'state': 'opened', 'order_by': 'created_at', 'sort': 'asc'},


### PR DESCRIPTION
Marge currently merges requests in ascending order of creation time.

The --merge-order='updated_at' flag can tell marge to merge in
ascending order of merge request update time.

An update includes an additional commit or comment on the merge request