### PR TITLE
Add "merge_first" label support

### DIFF
--- a/marge/bot.py
+++ b/marge/bot.py
@@ -154,7 +154,9 @@ class Bot(object):
             except git.GitError as err:
                 log.exception('BatchMergeJob failed: %s', err)
         log.info('Attempting to merge the oldest MR...')
-        merge_request = merge_requests[0]
+        # check if label `merge_first` exists, otherwise pick the oldest MR
+        merge_first = [MR for MR in merge_requests if "merge_first" in MR.labels]
+        merge_request = merge_requests[0] if not merge_first else merge_first[0]
         merge_job = self._get_single_job(
             project=project, merge_request=merge_request, repo=repo,
             options=self._config.merge_opts,

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -60,6 +60,10 @@ class MergeRequest(gitlab.Resource):
         return self.info['state']
 
     @property
+    def labels(self):
+        return self.info['labels']
+
+    @property
     def assignee_id(self):
         assignee = self.info['assignee'] or {}
         return assignee.get('id')


### PR DESCRIPTION
If you want to merge a MR first, simply give it a `merge_first` label.  
Tested in my Gitlab repo. 

This one will close #153