### PR TITLE
Support rebasing through GitLab's api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ ENV/
 .cache
 *.egg-info
 .coverage
+.pytest_cache
 
 # nix stuff
 result

--- a/marge/app.py
+++ b/marge/app.py
@@ -250,6 +250,11 @@ def main(args=None):
         if options.batch:
             logging.warning('Experimental batch mode enabled')
 
+        if options.use_merge_strategy:
+            fusion = bot.Fusion.merge
+        else:
+            fusion = bot.Fusion.rebase
+
         config = bot.BotConfig(
             user=user,
             ssh_key_file=ssh_key_file,
@@ -266,7 +271,7 @@ def main(args=None):
                 approval_timeout=options.approval_reset_timeout,
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
-                use_merge_strategy=options.use_merge_strategy,
+                fusion=fusion,
             ),
             batch=options.batch,
         )

--- a/marge/app.py
+++ b/marge/app.py
@@ -118,7 +118,7 @@ def _parse_config(args):
             "built-in rebase functionality, via their API. Note that Marge can't add\n"
             "information in the commits in this case.\n"
         ),
-    ),
+    )
     parser.add_argument(
         '--add-tested',
         action='store_true',

--- a/marge/app.py
+++ b/marge/app.py
@@ -226,7 +226,7 @@ def _secret_auth_token_and_ssh_key(options):
 
 
 def main(args=None):
-    if not args:
+    if args is None:
         args = sys.argv[1:]
     logging.basicConfig()
 

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -179,3 +179,4 @@ class BotConfig(namedtuple('BotConfig',
 
 
 MergeJobOptions = job.MergeJobOptions
+Fusion = job.Fusion

--- a/marge/gitlab.py
+++ b/marge/gitlab.py
@@ -21,8 +21,11 @@ class Api(object):
         log.debug('RESPONSE CODE: %s', response.status_code)
         log.debug('RESPONSE BODY: %r', response.content)
 
+        if response.status_code == 202:
+            return True  # Accepted
+
         if response.status_code == 204:
-            return True
+            return True  # NoContent
 
         if response.status_code < 300:
             return command.extract(response.json()) if command.extract else response.json()

--- a/marge/gitlab.py
+++ b/marge/gitlab.py
@@ -227,3 +227,6 @@ class Version(namedtuple('Version', 'release edition')):
     @property
     def is_ee(self):
         return self.edition == 'ee'
+
+    def __str__(self):
+        return '%s-%s' % ('.'.join(map(str, self.release)), self.edition)

--- a/marge/job.py
+++ b/marge/job.py
@@ -185,12 +185,14 @@ class MergeJob(object):
             def sufficient_approvals():
                 return merge_request.fetch_approvals().sufficient
             # Make sure we don't race by ensuring approvals have reset since the push
-            time_0 = datetime.utcnow()
             waiting_time_in_secs = 5
+            approval_timeout_in_secs = self._options.approval_timeout.total_seconds()
+            iterations = round(approval_timeout_in_secs / waiting_time_in_secs)
             log.info('Checking if approvals have reset')
-            while sufficient_approvals() and datetime.utcnow() - time_0 < self._options.approval_timeout:
+            while sufficient_approvals() and iterations:
                 log.debug('Approvals haven\'t reset yet, sleeping for %s secs', waiting_time_in_secs)
                 time.sleep(waiting_time_in_secs)
+                iterations -= 1
             if not sufficient_approvals():
                 approvals.reapprove()
 

--- a/marge/job.py
+++ b/marge/job.py
@@ -248,7 +248,7 @@ class MergeJob(object):
         if source_repo_url is None and source_branch == target_branch:
             raise CannotMerge('source and target branch seem to coincide!')
 
-        branch_update_done = commits_rewrite_done = changes_pushed = False
+        branch_update_done = commits_rewrite_done = False
         try:
             initial_mr_sha = merge_request.sha
             updated_sha = self.fuse(
@@ -264,25 +264,13 @@ class MergeJob(object):
                 raise CannotMerge('these changes already exist in branch `{}`'.format(target_branch))
             final_sha = self.add_trailers(merge_request) or updated_sha
             commits_rewrite_done = True
-            repo.push(source_branch, source_repo_url=source_repo_url, force=True)
-            changes_pushed = True
+            branch_was_modified = final_sha != initial_mr_sha
+            self.synchronize_mr_with_local_changes(merge_request, branch_was_modified, source_repo_url)
         except git.GitError:
             if not branch_update_done:
                 raise CannotMerge('got conflicts while rebasing, your problem now...')
             if not commits_rewrite_done:
                 raise CannotMerge('failed on filter-branch; check my logs!')
-            if not changes_pushed:
-                if final_sha != initial_mr_sha and (
-                     Branch.fetch_by_name(
-                        merge_request.source_project_id, merge_request.source_branch, self._api,
-                     ).protected
-                ):
-                    raise CannotMerge('Sorry, I can\'t push rewritten changes to protected branches!')
-                if self.opts.use_merge_strategy:
-                    raise CannotMerge('failed to push merged changes, check my logs!')
-                else:
-                    raise CannotMerge('failed to push rebased changes, check my logs!')
-
             raise
         else:
             return target_sha, updated_sha, final_sha
@@ -293,6 +281,32 @@ class MergeJob(object):
             if source_branch != 'master':
                 repo.checkout_branch('master')
                 repo.remove_branch(source_branch)
+
+    def synchronize_mr_with_local_changes(
+        self,
+        merge_request,
+        branch_was_modified,
+        source_repo_url=None,
+    ):
+        try:
+            self._repo.push(
+                merge_request.source_branch,
+                source_repo_url=source_repo_url,
+                force=True,
+            )
+        except git.GitError:
+            def fetch_remote_branch():
+                return Branch.fetch_by_name(
+                    merge_request.source_project_id,
+                    merge_request.source_branch,
+                    self._api,
+                )
+
+            if branch_was_modified and fetch_remote_branch().protected:
+                raise CannotMerge("Sorry, I can't push rewritten changes to protected branches!")
+
+            change_type = "merged" if self.opts.use_merge_strategy else "rebased"
+            raise CannotMerge('Failed to push %s changes, check my logs!' % change_type)
 
 
 def _get_reviewer_names_and_emails(commits, approvals, api):

--- a/tests/git_repo_mock.py
+++ b/tests/git_repo_mock.py
@@ -1,0 +1,242 @@
+import logging as log
+from collections import defaultdict
+from datetime import timedelta
+import functools
+import shlex
+
+import marge.git as git
+
+
+class RepoMock(git.Repo):
+
+    @classmethod
+    def init_for_merge_request(cls, merge_request, initial_target_sha, project, forked_project=None):
+        assert bool(forked_project) == (
+            merge_request.source_project_id != merge_request.target_project_id
+        )
+
+        target_url = project.ssh_url_to_repo
+        source_url = forked_project.ssh_url_to_repo if forked_project else target_url
+
+        remote_repos = defaultdict(GitRepoModel)
+        remote_repos[source_url].set_ref(merge_request.source_branch, merge_request.sha)
+        remote_repos[target_url].set_ref(merge_request.target_branch, initial_target_sha)
+
+        result = cls(
+            remote_url=target_url,
+            local_path='/tmp/blah',
+            ssh_key_file='/home/homer/.ssh/id_rsa',
+            timeout=timedelta(seconds=1000000),
+            reference='the_reference',
+        )
+
+        # pylint: disable=attribute-defined-outside-init
+        result.mock_impl = GitModel(origin=target_url, remote_repos=remote_repos)
+        return result
+
+    def git(self, *args, from_repo=True):
+        command = args[0]
+        command_args = args[1:]
+
+        log.info('Run: git %r %s', command, ' '.join(map(repr, command_args)))
+        assert from_repo == (command != 'clone')
+
+        command_impl_name = command.replace('-', '_')
+        command_impl = getattr(self.mock_impl, command_impl_name, None)
+        assert command_impl, ('git: Unexpected command %s' % command)
+        try:
+            result = command_impl(*command_args)
+        except Exception:
+            log.warning('Failed to simulate: git %r %s', command, command_args)
+            raise
+        else:
+            return self._pretend_result_comes_from_popen(result)
+
+    @staticmethod
+    def _pretend_result_comes_from_popen(result):
+        result_bytes = ('' if result is None else str(result)).encode('ascii')
+        return stub(stdout=result_bytes)
+
+
+class stub(object):  # pylint: disable=invalid-name,too-few-public-methods
+    def __init__(self, **kwargs):
+        self.__dict__ = kwargs
+
+
+class GitRepoModel(object):
+    def __init__(self, copy_of=None):
+        # pylint: disable=protected-access
+        self._refs = dict(copy_of._refs) if copy_of else {}
+
+    def set_ref(self, ref, commit):
+        self._refs[ref] = commit
+
+    def get_ref(self, ref):
+        return self._refs[ref]
+
+    def has_ref(self, ref):
+        return ref in self._refs
+
+    def del_ref(self, ref):
+        self._refs.pop(ref, None)
+
+    def __repr__(self):
+        return "<%s: %s>" % (type(self), self._refs)
+
+
+class GitModel(object):
+    def __init__(self, origin, remote_repos):
+        assert origin in remote_repos
+
+        self.remote_repos = remote_repos
+        self._local_repo = GitRepoModel()
+        self._remotes = dict(origin=origin)
+        self._remote_refs = {}
+        self._branch = None
+        self.on_push_callbacks = []
+
+    @property
+    def _head(self):
+        return self._local_repo.get_ref(self._branch)
+
+    def remote(self, *args):
+        action = args[0]
+        if action == 'rm':
+            _, remote = args
+            try:
+                self._remotes.pop(remote)
+            except KeyError:
+                raise git.GitError('No such remote: %s' % remote)
+
+        elif action == 'add':
+            _, remote, url = args
+            self._remotes[remote] = url
+        else:
+            assert False, args
+
+    def fetch(self, *args):
+        _, remote_name = args
+        assert args == ('--prune', remote_name)
+        remote_url = self._remotes[remote_name]
+        remote_repo = self.remote_repos[remote_url]
+        self._remote_refs[remote_name] = GitRepoModel(copy_of=remote_repo)
+
+    def checkout(self, *args):
+        if args[0] == '-B':  # -B == create if it doesn't exist
+            _, branch, start_point, _ = args
+            assert args == ('-B', branch, start_point, '--')
+            assert start_point == '' or '/' in start_point  # '' when "local"
+
+            # create if it doesn't exist
+            if not self._local_repo.has_ref(branch):
+                if start_point:
+                    remote_name, remote_branch = start_point.split('/')
+                    assert remote_branch == branch
+
+                    remote_url = self._remotes[remote_name]
+                    remote_repo = self.remote_repos[remote_url]
+                    commit = remote_repo.get_ref(branch)
+                    self._local_repo.set_ref(branch, commit)
+                else:
+                    self._local_repo.set_ref(branch, self._head)
+        else:
+            branch, _ = args
+            assert args == (branch, '--')
+            assert self._local_repo.has_ref(branch)
+
+        # checkout
+        self._branch = branch
+
+    def branch(self, *args):
+        if args[0] == "-D":
+            _, branch = args
+            assert self._branch != branch
+            self._local_repo.del_ref(branch)
+        else:
+            assert False
+
+    def rev_parse(self, arg):
+        if arg == 'HEAD':
+            return self._head
+
+        remote, branch = arg.split('/')
+        return self._remote_refs[remote].get_ref(branch)
+
+    def rebase(self, arg):
+        remote, branch = arg.split('/')
+        new_base = self._remote_refs[remote].get_ref(branch)
+        if new_base != self._head:
+            new_sha = 'rebase(%s onto %s)' % (self._head, new_base)
+            self._local_repo.set_ref(self._branch, new_sha)
+
+    def merge(self, arg):
+        remote, branch = arg.split('/')
+
+        other_ref = self._remote_refs[remote].get_ref(branch)
+        if other_ref != self._head:
+            new_sha = 'merge(%s with %s)' % (self._head, other_ref)
+            self._local_repo.set_ref(self._branch, new_sha)
+
+    def push(self, *args):
+        force_flag, remote_name, refspec = args
+
+        assert force_flag in ('', '--force')
+
+        branch, remote_branch = refspec.split(':')
+        remote_url = self._remotes[remote_name]
+        remote_repo = self.remote_repos[remote_url]
+
+        old_sha = remote_repo.get_ref(remote_branch)
+        new_sha = self._local_repo.get_ref(branch)
+
+        if force_flag:
+            remote_repo.set_ref(remote_branch, new_sha)
+        else:
+            expected_remote_sha = self._remote_refs[remote_name].get_ref(remote_branch)
+            if old_sha != expected_remote_sha:
+                raise git.GitError("conflict: can't push")
+            remote_repo.set_ref(remote_branch, new_sha)
+
+        for callback in self.on_push_callbacks:
+            callback(
+                remote_url=remote_url,
+                remote_branch=remote_branch,
+                old_sha=old_sha,
+                new_sha=new_sha,
+            )
+
+    def config(self, *args):
+        assert len(args) == 2 and args[0] == '--get'
+        _, remote, _ = elems = args[1].split('.')
+        assert elems == ['remote', remote, 'url'], elems
+        return self._remotes[remote]
+
+    def diff_index(self, *args):
+        assert args == ('--quiet', 'HEAD')
+        # we don't model dirty index
+
+    def ls_files(self, *args):
+        assert args == ('--others',)
+        # we don't model untracked files
+
+    def filter_branch(self, *args):
+        _, _, filter_cmd, commit_range = args
+        assert args == ('--force', '--msg-filter', filter_cmd, commit_range)
+
+        trailers_var, python, script_path = shlex.split(filter_cmd)
+        _, trailers_str = trailers_var.split('=')
+
+        assert trailers_var == "TRAILERS=%s" % trailers_str
+        assert python == "python3"
+        assert script_path.endswith("marge/trailerfilter.py")
+
+        trailers = list(sorted(set(line.split(':')[0] for line in trailers_str.split('\n'))))
+        assert trailers
+
+        new_sha = functools.reduce(
+            lambda x, f: "add-%s(%s)" % (f, x),
+            [trailer.lower() for trailer in trailers],
+            self._head
+        )
+        self._local_repo.set_ref(self._branch, new_sha)
+        return new_sha

--- a/tests/gitlab_api_mock.py
+++ b/tests/gitlab_api_mock.py
@@ -24,7 +24,7 @@ def commit(commit_id, status):
 
 
 class MockLab(object):  # pylint: disable=too-few-public-methods
-    def __init__(self, gitlab_url=None, fork=False, merge_request_options=None):
+    def __init__(self, initial_master_sha='505e', gitlab_url=None, fork=False, merge_request_options=None):
         self.gitlab_url = gitlab_url = gitlab_url or 'http://git.example.com'
         self.api = api = Api(gitlab_url=gitlab_url, auth_token='no-token', initial_state='initial')
 
@@ -35,9 +35,7 @@ class MockLab(object):  # pylint: disable=too-few-public-methods
         api.add_user(self.user_info, is_current=True)
 
         self.project_info = dict(test_project.INFO)
-        self.forked_project_info = {**self.project_info, **{'id': 4321}}
         api.add_project(self.project_info)
-        api.add_project(self.forked_project_info)
 
         self.commit_info = dict(test_commit.INFO)
         api.add_commit(self.project_info['id'], self.commit_info)
@@ -62,11 +60,21 @@ class MockLab(object):  # pylint: disable=too-few-public-methods
         }
         if merge_request_options is not None:
             self.merge_request_info.update(merge_request_options)
+
         if fork:
+            self.forked_project_info = dict(
+                self.project_info,
+                id=4321,
+                ssh_url_to_repo='ssh://some.other.project/stuff',
+            )
+            api.add_project(self.forked_project_info)
             self.merge_request_info.update({'iid': 55, 'source_project_id': '4321'})
+        else:
+            self.forked_project_info = None
+
         api.add_merge_request(self.merge_request_info)
 
-        self.initial_master_sha = '505e'
+        self.initial_master_sha = initial_master_sha
         self.approvals_info = dict(
             test_approvals.INFO,
             id=self.merge_request_info['id'],

--- a/tests/gitlab_api_mock.py
+++ b/tests/gitlab_api_mock.py
@@ -109,7 +109,7 @@ class Api(gitlab.Api):
             self.state,
         )
         try:
-            response, next_state = self._find(command, sudo)
+            response, next_state, side_effect = self._find(command, sudo)
         except KeyError:
             page = command.args.get('page')
             if page == 0:
@@ -132,13 +132,15 @@ class Api(gitlab.Api):
             if next_state:
                 self.state = next_state
 
+            if side_effect:
+                side_effect()
             return response()
 
     def _find(self, command, sudo):
         more_specific = self._transitions.get(_key(command, sudo, self.state))
         return more_specific or self._transitions[_key(command, sudo, None)]
 
-    def add_transition(self, command, response, sudo=None, from_state=None, to_state=None):
+    def add_transition(self, command, response, sudo=None, from_state=None, to_state=None, side_effect=None):
         from_states = from_state if isinstance(from_state, list) else [from_state]
 
         for _from_state in from_states:
@@ -150,7 +152,7 @@ class Api(gitlab.Api):
                 show_from,
                 show_from if to_state is None else repr(to_state),
             )
-            self._transitions[_key(command, sudo, _from_state)] = (response, to_state)
+            self._transitions[_key(command, sudo, _from_state)] = (response, to_state, side_effect)
 
     def add_resource(self, path, info, sudo=None, from_state=None, to_state=None):
         self.add_transition(GET(path.format(attrs(info))), Ok(info), sudo, from_state, to_state)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -150,17 +150,19 @@ def test_add_reviewers():
             assert bot.config.merge_opts != job.MergeJobOptions.default()
             assert bot.config.merge_opts == job.MergeJobOptions.default(add_reviewers=True)
 
+
 def test_rebase_remotely_option_conflicts():
     for conflicting_flag in ['--use-merge-strategy', '--add-tested', '--add-part-of', '--add-reviewers']:
         with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
             with pytest.raises(app.MargeBotCliArgError):
-                with main('--rebase-remotely %s' % conflicting_flag) as bot:
+                with main('--rebase-remotely %s' % conflicting_flag):
                     pass
+
 
 def test_impersonate_approvers():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with pytest.raises(AssertionError):
-            with main('--impersonate-approvers') as bot:
+            with main('--impersonate-approvers'):
                 pass
 
     with env(MARGE_AUTH_TOKEN="ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -107,7 +107,7 @@ def test_use_merge_strategy():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with main('--use-merge-strategy') as bot:
             assert bot.config.merge_opts != job.MergeJobOptions.default()
-            assert bot.config.merge_opts == job.MergeJobOptions.default(use_merge_strategy=True)
+            assert bot.config.merge_opts == job.MergeJobOptions.default(fusion=job.Fusion.merge)
 
 
 def test_add_tested():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, Mock, patch, create_autospec
 
 import pytest
 
-from marge.job import CannotMerge, MergeJob, MergeJobOptions, SkipMerge
+from marge.job import CannotMerge, Fusion, MergeJob, MergeJobOptions, SkipMerge
 import marge.interval
 import marge.git
 import marge.gitlab
@@ -147,7 +147,7 @@ class TestJob(object):
         merge_request.unassign.assert_called_once()
 
     def test_fuse_using_rebase(self):
-        merge_job = self.get_merge_job(options=MergeJobOptions.default(use_merge_strategy=False))
+        merge_job = self.get_merge_job(options=MergeJobOptions.default(fusion=Fusion.rebase))
         branch_a = 'A'
         branch_b = 'B'
 
@@ -161,7 +161,7 @@ class TestJob(object):
         )
 
     def test_fuse_using_merge(self):
-        merge_job = self.get_merge_job(options=MergeJobOptions.default(use_merge_strategy=True))
+        merge_job = self.get_merge_job(options=MergeJobOptions.default(fusion=Fusion.merge))
         branch_a = 'A'
         branch_b = 'B'
 
@@ -185,7 +185,7 @@ class TestMergeJobOptions(object):
             approval_timeout=timedelta(seconds=0),
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
-            use_merge_strategy=False,
+            fusion=Fusion.rebase,
         )
 
     def test_default_ci_time(self):


### PR DESCRIPTION
Here's an attempt to add support for GitLab's new "merge_request/rebase" endpoint (#157), which should enable using marge in public gitlab instances (#159). It is enabled with `--rebase-remotely` and conflicts with `--use-merge-strategy` and all the `add-xxx` options.

It works by performing the rebase locally but replacing the `git push --force` step by a call to [this endpoint](https://docs.gitlab.com/ee/api/merge_requests.html#rebase-a-merge-request).

Because the change happens inside `MergeJob.update_from_target_branch_and_push()`, it wouldn't have been picked  by the mocklab tests, where this method was being replaced by a mock. So I went down a bit of a rabbit hole at first and started by adding a mock of git, to fix this. The mock works by hooking into the `Repo.git()` method and interpreting the git commands that marge emits, using an extremely simplified model of git.

Because now these tests can see inside `update_from_target_branch_and_push()`, I make it so that they run on (almost) all combinations of fusion-strategies and trailer-adding, which caught a small bug in the handling of protected branches. 

While the PR is a bit large, the individual commits should be smallish and self-contained.. 