### PR TITLE
 Only fetch projects with min access level

### DIFF
--- a/marge/bot.py
+++ b/marge/bot.py
@@ -91,7 +91,7 @@ class Bot(object):
         for project in projects:
             project_name = project.path_with_namespace
 
-            if project.access_level.value < AccessLevel.reporter.value:
+            if project.access_level < AccessLevel.reporter:
                 log.warning("Don't have enough permissions to browse merge requests in %s!", project_name)
                 continue
             merge_requests = self._get_merge_requests(project, project_name)

--- a/marge/project.py
+++ b/marge/project.py
@@ -1,5 +1,5 @@
 import logging as log
-from enum import Enum, unique
+from enum import IntEnum, unique
 from functools import partial
 
 from . import gitlab
@@ -78,7 +78,7 @@ class Project(gitlab.Resource):
 
 
 @unique
-class AccessLevel(Enum):
+class AccessLevel(IntEnum):
     # See https://docs.gitlab.com/ce/api/access_requests.html
     guest = 10
     reporter = 20

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 import pytest
 
-from marge.gitlab import Api, GET
+from marge.gitlab import Api, GET, Version
 from marge.project import AccessLevel, Project
 
 
@@ -67,12 +67,10 @@ class TestProject(object):
 
         api = self.api
         api.collect_all_pages = Mock(return_value=[prj1, prj2])
+        api.version = Mock(return_value=Version.parse("11.2.0-ee"))
 
         result = Project.fetch_all_mine(api)
-        api.collect_all_pages.assert_called_once_with(GET(
-            '/projects',
-            {'membership': True, 'with_merge_requests_enabled': True},
-        ))
+        api.collect_all_pages.assert_called_once()
         assert [prj.info for prj in result] == [prj1, prj2]
 
     def test_properties(self):


### PR DESCRIPTION
If we're on an appropriate GitLab version, that is. GitLab doesn't return the right permissions for projects belonging to the user if the project is in a subgroup, and Marge is set as a member of the top-level group[1]. This is rather annoying as Marge will then complain that she doesn't have permissions for a project when she does.

A new field available in GitLab version >= 11.2 allows us to only fetch projects for which we have a certain access level. This returns the right projects even with nested groups, so we can prefer this method if it is available.

Fixes: #156 