### PR TITLE
Fix rebase API race condition

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -138,17 +138,18 @@ class MergeRequest(gitlab.Resource):
             # We wanted to rebase and someone just happened to press the button for us!
             log.info('A rebase was already in progress on the merge request!')
 
-        max_attempts = 30
-        wait_between_attempts_in_secs = 1
+        # Wait for at most 2 minutes until giving up.
+        max_attempts = 24
+        wait_between_attempts_in_secs = 5
 
         for _ in range(max_attempts):
+            time.sleep(wait_between_attempts_in_secs)
+
             self.refetch_info()
             if not self.rebase_in_progress:
                 if self.merge_error:
                     raise MergeRequestRebaseFailed(self.merge_error)
                 return
-
-            time.sleep(wait_between_attempts_in_secs)
 
         raise TimeoutError('Waiting for merge request to be rebased by GitLab')
 


### PR DESCRIPTION
This follows my observations raised on https://github.com/smarkets/marge-bot/pull/160#issuecomment-482013649. I tried to change as little as possible, because I'm not that familiar with Python nor the intricacies of GitLab's API.

The fix is described in detail in https://github.com/kgilden/marge-bot/commit/89207cb6a10191ba82eafc866545d7fd01603fb8.