### PR TITLE
nix: formatting, smarter `src` in marge.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
-let pkgs = import ./pinnedNixpkgs.nix;
+let
+  pkgs = import ./pinnedNixpkgs.nix;
 in
-pkgs.callPackage ./marge.nix {}
+  pkgs.callPackage ./marge.nix {}

--- a/dockerize.nix
+++ b/dockerize.nix
@@ -16,7 +16,9 @@ in
       with pkgs; [
         bash
         coreutils
+        git
         glibcLocales
+        openssh
       ] ++ [ marge ];
     config = {
       Entrypoint = [ "/bin/marge.app" ];

--- a/dockerize.nix
+++ b/dockerize.nix
@@ -1,20 +1,28 @@
 { pkgs ? import ./pinnedNixpkgs.nix }:
-let callPackage = pkgs.lib.callPackageWith (pkgs);
-    marge = callPackage ./marge.nix {};
-    version = marge.version;
+let
+  marge = pkgs.callPackage ./marge.nix {};
+  version = marge.version;
 in
-pkgs.dockerTools.buildImage {
-  name = "smarkets/marge-bot";
-  tag = "${version}";
-  # minimal user setup, so ssh won't whine 'No user exists for uid 0'
-  runAsRoot = ''
-  #!${pkgs.stdenv.shell}
-  ${pkgs.dockerTools.shadowSetup}
-  mkdir -p /root/.ssh
-  '';
-  contents = [marge pkgs.bash pkgs.coreutils pkgs.openssh pkgs.glibcLocales];
-  config = {
-    Entrypoint = [ "/bin/marge.app" ];
-    Env = ["LANG=en_US.UTF-8" ''LOCALE_ARCHIVE=/lib/locale/locale-archive''];
-  };
-}
+  pkgs.dockerTools.buildImage {
+    name = "smarkets/marge-bot";
+    tag = "${version}";
+    # minimal user setup, so ssh won't whine 'No user exists for uid 0'
+    runAsRoot = ''
+      #!${pkgs.stdenv.shell}
+      ${pkgs.dockerTools.shadowSetup}
+      mkdir -p /root/.ssh
+    '';
+    contents =
+      with pkgs; [
+        bash
+        coreutils
+        glibcLocales
+      ] ++ [ marge ];
+    config = {
+      Entrypoint = [ "/bin/marge.app" ];
+      Env = [
+        "LANG=en_US.UTF-8"
+        "LOCALE_ARCHIVE=/lib/locale/locale-archive"
+      ];
+    };
+  }

--- a/marge.nix
+++ b/marge.nix
@@ -1,22 +1,40 @@
-{pkgs ? import ./pinnedNixpkgs.nix }:
-let version = builtins.replaceStrings ["\n"] [""] (builtins.readFile ./version);
-    python = (import ./requirements.nix { inherit pkgs; });
-    py = python.packages;
+{ pkgs
+, lib
+}:
+let
+  python = import ./requirements.nix { inherit pkgs; };
+  version = lib.fileContents ./version;
 in
-python.mkDerivation {
-  version = "${version}";
-  name = "marge-${version}";
-  src = ./.;
-  buildInputs = [py.pytest py.pytest-cov py.pytest-flake8 py.pytest-pylint py.pytest-runner];
-  propagatedBuildInputs = [py.ConfigArgParse py.maya py.PyYAML py.requests pkgs.openssh pkgs.git];
-  meta = {
-    homepage = "https://github.com/smarkets/marge-bot";
-    description = "A build bot for GitLab";
-    license = with pkgs.lib.licenses; [bsd3] ;
-    maintainers =  [
-      "Alexander Schmolck <alexander.schmolck@smarkets.com>"
-      "Jaime Lennox <jaime.lennox@smarkets.com>"
+  python.mkDerivation {
+    version = "${version}";
+    name = "marge-${version}";
+    src = lib.sourceByRegex ./. [
+      "marge(/.*\.py)?"
+      "tests(/.*\.py)?"
+      "marge\.app"
+      "pylintrc"
+      "setup\.cfg"
+      "setup\.py"
+      "version"
     ];
-    platforms = pkgs.lib.platforms.linux ++ pkgs.lib.platforms.darwin;
-  };
- }
+    checkInputs = with python.packages; [
+      pytest
+      pytest-cov
+      pytest-flake8
+      pytest-pylint
+      pytest-runner
+    ];
+    propagatedBuildInputs =
+      (with python.packages; [ ConfigArgParse maya PyYAML requests ]) ++
+      (with pkgs; [ git openssh ]);
+    meta = {
+      homepage = "https://github.com/smarkets/marge-bot";
+      description = "A build bot for GitLab";
+      license = lib.licenses.bsd3;
+      maintainers =  [
+        "Alexander Schmolck <alexander.schmolck@smarkets.com>"
+        "Jaime Lennox <jaime.lennox@smarkets.com>"
+      ];
+      platforms = pkgs.lib.platforms.linux ++ pkgs.lib.platforms.darwin;
+    };
+  }

--- a/marge.nix
+++ b/marge.nix
@@ -24,9 +24,9 @@ in
       pytest-pylint
       pytest-runner
     ];
-    propagatedBuildInputs =
-      (with python.packages; [ ConfigArgParse maya PyYAML requests ]) ++
-      (with pkgs; [ git openssh ]);
+    propagatedBuildInputs = with python.packages; [
+      ConfigArgParse maya PyYAML requests
+    ];
     meta = {
       homepage = "https://github.com/smarkets/marge-bot";
       description = "A build bot for GitLab";

--- a/pinnedNixpkgs.nix
+++ b/pinnedNixpkgs.nix
@@ -1,9 +1,10 @@
 let
   fetchFromGitHub = (import <nixpkgs> {}).fetchFromGitHub;
-  pkgs = import (fetchFromGitHub {
-                   owner  = "NixOS";
-                   repo   = "nixpkgs";
-                   rev    = "90afb0c10fe6f437fca498298747b2bcb6a77d39";
-                   sha256 = "0mvzdw5aygi1vjnvm0bc8bp7iwb9rypiqg749m6a6km84m7srm0w";
-                 }) {};
-in pkgs
+  pinned = fetchFromGitHub {
+    owner  = "NixOS";
+    repo   = "nixpkgs";
+    rev    = "90afb0c10fe6f437fca498298747b2bcb6a77d39";
+    sha256 = "0mvzdw5aygi1vjnvm0bc8bp7iwb9rypiqg749m6a6km84m7srm0w";
+  };
+in
+  import pinned {}


### PR DESCRIPTION
`src = ./.;` would include everything, including the autogenerated `result` symlink and `.git`. This PR limits it to a required subset of files; changing README or reformatting `*.nix` won't trigger a rebuild anymore.