### PR TITLE
Fix single assignee support

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -41,7 +41,8 @@ class MergeRequest(gitlab.Resource):
         ))
         my_merge_request_infos = [
             mri for mri in all_merge_request_infos
-            if user_id in [assignee.get('id') for assignee in mri.get('assignees', [])]
+            if ((mri['assignee'] or {}).get('id') == user_id) or
+               (user_id in [assignee.get('id') for assignee in mri.get('assignees', [])])
         ]
 
         return [cls(api, merge_request_info) for merge_request_info in my_merge_request_infos]
@@ -72,8 +73,10 @@ class MergeRequest(gitlab.Resource):
 
     @property
     def assignee_ids(self):
-        assignees = self.info['assignees'] or []
-        return [assignee.get('id') for assignee in assignees]
+        if 'assignees' in self.info:
+            return [assignee.get('id') for assignee in self.info['assignees']]
+        else:
+            return [(self.info['assignee'] or {}).get('id')]
 
     @property
     def author_id(self):


### PR DESCRIPTION
After this pull request https://github.com/smarkets/marge-bot/pull/186/files

Single assigned gitlab merge request does not work anymore because the key `assignees` does not exist.

Now both worlds are supported.