### PR TITLE
Update API for remove source branch on merge.

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -156,7 +156,7 @@ class MergeRequest(gitlab.Resource):
         return self._api.call(PUT(
             '/projects/{0.project_id}/merge_requests/{0.iid}/merge'.format(self),
             dict(
-                remove_source_branch=remove_branch,
+                should_remove_source_branch=remove_branch,
                 merge_when_pipeline_succeeds=True,
                 sha=sha or self.sha,  # if provided, ensures what is merged is what we want (or fails)
             ),

--- a/tests/test_merge_request.py
+++ b/tests/test_merge_request.py
@@ -158,7 +158,7 @@ class TestMergeRequest:
                 '/projects/1234/merge_requests/54/merge',
                 dict(
                     merge_when_pipeline_succeeds=True,
-                    remove_source_branch=boolean,
+                    should_remove_source_branch=boolean,
                     sha='badc0de',
                 )
             ))
@@ -169,7 +169,7 @@ class TestMergeRequest:
             '/projects/1234/merge_requests/54/merge',
             dict(
                 merge_when_pipeline_succeeds=True,
-                remove_source_branch=False,
+                should_remove_source_branch=False,
                 sha='g00dc0de',
             )
         ))

--- a/tests/test_single_job.py
+++ b/tests/test_single_job.py
@@ -131,7 +131,7 @@ class SingleJobMockLab(MockLab):
         api.add_transition(
             PUT(
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=self.merge_request_info['iid']),
-                dict(sha=rewritten_sha, remove_source_branch=True, merge_when_pipeline_succeeds=True),
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
             ),
             Ok({}),
             from_state=['passed', 'skipped'], to_state='merged',
@@ -519,7 +519,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=mocklab.merge_request_info['iid']),
                 dict(
                     sha=first_rewritten_sha,
-                    remove_source_branch=True,
+                    should_remove_source_branch=True,
                     merge_when_pipeline_succeeds=True,
                 ),
             ),
@@ -572,7 +572,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
         api.add_transition(
             PUT(
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=mocklab.merge_request_info['iid']),
-                dict(sha=rewritten_sha, remove_source_branch=True, merge_when_pipeline_succeeds=True),
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
             ),
             Error(marge.gitlab.NotFound(404, {'message': '404 Branch Not Found'})),
             from_state='passed', to_state='someone_else_merged',
@@ -591,7 +591,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
         api.add_transition(
             PUT(
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=mocklab.merge_request_info['iid']),
-                dict(sha=rewritten_sha, remove_source_branch=True, merge_when_pipeline_succeeds=True),
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
             ),
             Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
             from_state='passed', to_state='now_is_wip',
@@ -612,7 +612,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
         api.add_transition(
             PUT(
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=mocklab.merge_request_info['iid']),
-                dict(sha=rewritten_sha, remove_source_branch=True, merge_when_pipeline_succeeds=True),
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
             ),
             Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
             from_state='passed', to_state='rejected_by_git_hook',
@@ -636,7 +636,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
         api.add_transition(
             PUT(
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=mocklab.merge_request_info['iid']),
-                dict(sha=rewritten_sha, remove_source_branch=True, merge_when_pipeline_succeeds=True),
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
             ),
             Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
             from_state='passed', to_state='unresolved_discussions',
@@ -661,7 +661,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
         api.add_transition(
             PUT(
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=mocklab.merge_request_info['iid']),
-                dict(sha=rewritten_sha, remove_source_branch=True, merge_when_pipeline_succeeds=True),
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
             ),
             Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
             from_state='passed', to_state='oops_someone_closed_it',
@@ -682,7 +682,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
         api.add_transition(
             PUT(
                 '/projects/1234/merge_requests/{iid}/merge'.format(iid=mocklab.merge_request_info['iid']),
-                dict(sha=rewritten_sha, remove_source_branch=True, merge_when_pipeline_succeeds=True),
+                dict(sha=rewritten_sha, should_remove_source_branch=True, merge_when_pipeline_succeeds=True),
             ),
             Error(marge.gitlab.MethodNotAllowed(405, {'message': '405 Method Not Allowed'})),
             from_state='passed', to_state='rejected_for_mysterious_reasons',


### PR DESCRIPTION
To accept an MR and remove the source branch one has to set `should_remove_source_branch` like mention here:
https://docs.gitlab.com/ee/api/merge_requests.html#accept-mr

I also checked older versions (10.3). It was always `should`. Maybe in v3 it was different.


