### PR TITLE
Make the docker image smaller; cosmetics

### DIFF
--- a/dockerize.nix
+++ b/dockerize.nix
@@ -11,10 +11,10 @@ let
         mkdir -p root/.ssh
         mkdir -p etc/pam.d
         echo "root:x:0:0::/root:/bin/sh" >etc/passwd
-        echo "root:!x:::::::" > etc/shadow
-        echo "root:x:0:" > etc/group
-        echo "root:x::" > etc/gshadow
-        cat > etc/pam.d/other <<EOF
+        echo "root:!x:::::::" >etc/shadow
+        echo "root:x:0:" >etc/group
+        echo "root:x::" >etc/gshadow
+        cat >etc/pam.d/other <<\EOF
         account sufficient pam_unix.so
         auth sufficient pam_rootok.so
         password requisite pam_unix.so nullok sha512
@@ -28,10 +28,8 @@ in
     contents =
       with pkgs; [
         basicShadow
-        bash
-        coreutils
-        git
-        glibcLocales
+        busybox
+        gitMinimal
         openssh
       ] ++ [ marge ];
     config = {


### PR DESCRIPTION
The docker image is a bit bloated, I do not think we need kitchen-sink
git nor full coreutils etc. These changes slim down the image to around
85 from 165MiB packed or about 280MiB from 500MiB unpacked.

Also did some minor reformatting.