### PR TITLE
antiflood option for comments

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -174,6 +174,12 @@ def _parse_config(args):
         help='How long to wait for CI to pass.\n',
     )
     parser.add_argument(
+        '--comment-antiflood',
+        type=time_interval,
+        default='15min',
+        help='How long to wait before the bot writes the same comment.\n',
+    )
+    parser.add_argument(
         '--max-ci-time-in-minutes',
         type=int,
         default=None,
@@ -298,6 +304,7 @@ def main(args=None):
                 approval_timeout=options.approval_reset_timeout,
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
+                comment_antiflood=options.comment_antiflood,
                 fusion=fusion,
             ),
             batch=options.batch,

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -128,7 +128,7 @@ class MergeRequest(gitlab.Resource):
         self.refetch_notes()
         last_note = next(iter(self._notes))
 
-        if last_note.get('body') != message and last_note.get('created_at').utcnow() - time_0 < self._options.comment_antiflood:
+        if last_note.get('body') != message or last_note.get('created_at').utcnow() - time_0 > self._options.comment_antiflood:
 
         if self._api.version().release >= (9, 2, 2):
             notes_url = '/projects/{0.project_id}/merge_requests/{0.iid}/notes'.format(self)

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -120,7 +120,16 @@ class MergeRequest(gitlab.Resource):
     def refetch_info(self):
         self._info = self._api.call(GET('/projects/{0.project_id}/merge_requests/{0.iid}'.format(self)))
 
+    def refetch_notes(self):
+        self._notes = self._api.call(GET('/projects/{0.project_id}/merge_requests/{0.iid}/notes?sort=desc&order_by=created_at'.format(self)))
+
     def comment(self, message):
+        time_0 = datetime.utcnow()
+        self.refetch_notes()
+        last_note = next(iter(self._notes))
+
+        if last_note.get('body') != message and last_note.get('created_at').utcnow() - time_0 < self._options.comment_antiflood:
+
         if self._api.version().release >= (9, 2, 2):
             notes_url = '/projects/{0.project_id}/merge_requests/{0.iid}/notes'.format(self)
         else:


### PR DESCRIPTION
Attempt to solve https://github.com/smarkets/marge-bot/issues/189

Add an option `--comment-antiflood` to avoid a flood with the same comment.