### PR TITLE
Fix unassign when author is marge

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -177,7 +177,7 @@ class MergeRequest(gitlab.Resource):
         ))
 
     def unassign(self):
-        return self.assign_to(None)
+        return self.assign_to(0)
 
     def fetch_approvals(self):
         # 'id' needed for for GitLab 9.2.2 hack (see Approvals.refetch_info())

--- a/tests/test_merge_request.py
+++ b/tests/test_merge_request.py
@@ -82,7 +82,7 @@ class TestMergeRequest:
 
     def test_unassign(self):
         self.merge_request.unassign()
-        self.api.call.assert_called_once_with(PUT('/projects/1234/merge_requests/54', {'assignee_id': None}))
+        self.api.call.assert_called_once_with(PUT('/projects/1234/merge_requests/54', {'assignee_id': 0}))
 
     def test_rebase_was_not_in_progress_no_error(self):
         expected = [


### PR DESCRIPTION
According to the docs:

"Set to 0 or provide an empty value to unassign all assignees."[1]

So setting to `None` seems like it would work, although in practice it doesn't.

I've manually tested with `0` and it works fine.

[1] https://docs.gitlab.com/ee/api/merge_requests.html#update-mr

Fixes: #189 