### PR TITLE
Fetch pipelines by merge request instead of branch

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -135,11 +135,19 @@ class MergeJob:
     def get_mr_ci_status(self, merge_request, commit_sha=None):
         if commit_sha is None:
             commit_sha = merge_request.sha
-        pipelines = Pipeline.pipelines_by_branch(
-            merge_request.source_project_id,
-            merge_request.source_branch,
-            self._api,
-        )
+
+        if self._api.version().release >= (10, 5, 0):
+            pipelines = Pipeline.pipelines_by_merge_request(
+                merge_request.source_project_id,
+                merge_request.iid,
+                self._api,
+            )
+        else:
+            pipelines = Pipeline.pipelines_by_branch(
+                merge_request.source_project_id,
+                merge_request.source_branch,
+                self._api,
+            )
         current_pipeline = next(iter(pipeline for pipeline in pipelines if pipeline.sha == commit_sha), None)
 
         if current_pipeline:

--- a/marge/pipeline.py
+++ b/marge/pipeline.py
@@ -31,6 +31,17 @@ class Pipeline(gitlab.Resource):
 
         return [cls(api, pipeline_info, project_id) for pipeline_info in pipelines_info]
 
+    @classmethod
+    def pipelines_by_merge_request(cls, project_id, merge_request_iid, api):
+        """Fetch all pipelines for a merge request in descending order of pipeline ID."""
+        pipelines_info = api.call(GET(
+            '/projects/{project_id}/merge_requests/{merge_request_iid}/pipelines'.format(
+                project_id=project_id, merge_request_iid=merge_request_iid,
+            )
+        ))
+        pipelines_info.sort(key=lambda pipeline_info: pipeline_info['id'], reverse=True)
+        return [cls(api, pipeline_info, project_id) for pipeline_info in pipelines_info]
+
     @property
     def project_id(self):
         return self.info['project_id']

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -30,6 +30,17 @@ class TestPipeline:
         ))
         assert [pl.info for pl in result] == [pl1, pl2]
 
+    def test_pipelines_by_merge_request(self):
+        api = self.api
+        pl1, pl2 = INFO, dict(INFO, id=48)
+        api.call = Mock(return_value=[pl1, pl2])
+
+        result = Pipeline.pipelines_by_merge_request(project_id=1234, merge_request_iid=1, api=api)
+        api.call.assert_called_once_with(GET(
+            '/projects/1234/merge_requests/1/pipelines',
+        ))
+        assert [pl.info for pl in result] == [pl2, pl1]
+
     def test_properties(self):
         pipeline = Pipeline(api=self.api, project_id=1234, info=INFO)
         assert pipeline.id == 47


### PR DESCRIPTION
... if possible.

Since we operate on merge requests this makes more sense, but the feature was only available from version 10.5.

It allows us to fetch all pipelines for a particular merge request, including detached ones, which would otherwise not be fetched due to a different `ref` format.

An annoyance of this route is that it doesn't allow ordering or sorting, which we use to determine the latest pipeline by. However it's very simple to just do this ourselves; the only downside is this is no longer
customizable, but nothing in the codebase appears to use this feature anyway.

The batch job tries cancel pipelines by their status, which we can't filter by for this route (unless we do it manually as well) so I've left that using the old method. This can mean some detached pipelines may
continue running after a batch job has completed, but this seems like a very minor issue.

Fixes: #185