### PR TITLE
Fork fixes

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -138,7 +138,7 @@ class MergeJob:
 
         if self._api.version().release >= (10, 5, 0):
             pipelines = Pipeline.pipelines_by_merge_request(
-                merge_request.source_project_id,
+                merge_request.target_project_id,
                 merge_request.iid,
                 self._api,
             )

--- a/marge/job.py
+++ b/marge/job.py
@@ -243,6 +243,9 @@ class MergeJob:
             )
         return source_project
 
+    def get_target_project(self, merge_request):
+        return Project.fetch_by_id(merge_request.target_project_id, api=self._api)
+
     def fuse(self, source, target, source_repo_url=None, local=False):
         # NOTE: this leaves git switched to branch_a
         strategies = {

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -48,6 +48,7 @@ class SingleMergeJob(MergeJob):
         while not updated_into_up_to_date_target_branch:
             self.ensure_mergeable_mr(merge_request)
             source_project, source_repo_url, _ = self.fetch_source_project(merge_request)
+            target_project = self.get_target_project(merge_request)
             try:
                 # NB. this will be a no-op if there is nothing to update/rewrite
 
@@ -72,7 +73,7 @@ class SingleMergeJob(MergeJob):
 
             self.maybe_reapprove(merge_request, approvals)
 
-            if source_project.only_allow_merge_if_pipeline_succeeds:
+            if target_project.only_allow_merge_if_pipeline_succeeds:
                 self.wait_for_ci_to_pass(merge_request, actual_sha)
                 time.sleep(2)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -67,7 +67,7 @@ class TestJob:
 
             if use_merge_request_pipelines:
                 pipeline_class.pipelines_by_merge_request.assert_called_once_with(
-                    merge_request.source_project_id,
+                    merge_request.target_project_id,
                     merge_request.iid,
                     merge_job._api,
                 )


### PR DESCRIPTION
Fixes a few places where we should be checking the target project instead of the source project. As such, these issues only currently affect merge requests from forked projects.