### PR TITLE
Add Only allow merge requests to be merged if the pipeline succeeds requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Once you have the token, put it in a file, e.g. `marge-bot.token`.
 
 Finally, create a new ssh key-pair, e.g like so
 
+Margebot also requires the [Only allow merge requests to be merged if the pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html#only-allow-merge-requests-to-be-merged-if-the-pipeline-succeeds) setting to be enabled.
+
 ```bash
 ssh-keygen -t ed25519 -C marge-bot@invalid -f marge-bot-ssh-key -P ''
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ this is only to be found out when the commits have already landed.
 GitLab (in their [enterprise edition](https://about.gitlab.com/products/)),
 offers an important improvement here with
 their
-[semi-linear history and fast-forward](https://docs.gitlab.com/ee/user/project/merge_requests/) merge
+[semi-linear history and fast-forward](https://docs.gitlab.com/ee/user/project/merge_requests/#semi-linear-history-merge-requests) merge
 request methods: in both cases a merge request can only be accepted if the
 resulting master branch will be effectively the same as the merge request branch
 on which CI has passed. If master has changed since the tests were last ran, it


### PR DESCRIPTION
**Issue**
Margebot requires the Only allow merge requests to be merged if the pipeline succeeds setting to be enabled for both single branch merging and batch merging. I could not find any documentation on this. I also wonder if this method should be changed such that if master is protected this setting doesn't need to enabled as margebot would implicitly enforce this.

I have fixed a link to semi-linear history and fast-forward in the Readme as this link went to the main merge requests page rather than the specific section.

I also added a sentence in the `Running` section explaining that this setting must be enabled with a link to how this is done.