### PR TITLE
Pass the correct value for merge_when_pipeline_succeeds

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -158,12 +158,12 @@ class MergeRequest(gitlab.Resource):
 
         raise TimeoutError('Waiting for merge request to be rebased by GitLab')
 
-    def accept(self, remove_branch=False, sha=None):
+    def accept(self, remove_branch=False, sha=None, merge_when_pipeline_succeeds=True):
         return self._api.call(PUT(
             '/projects/{0.project_id}/merge_requests/{0.iid}/merge'.format(self),
             dict(
                 should_remove_source_branch=remove_branch,
-                merge_when_pipeline_succeeds=True,
+                merge_when_pipeline_succeeds=merge_when_pipeline_succeeds,
                 sha=sha or self.sha,  # if provided, ensures what is merged is what we want (or fails)
             ),
         ))

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -80,7 +80,11 @@ class SingleMergeJob(MergeJob):
             self.ensure_mergeable_mr(merge_request)
 
             try:
-                merge_request.accept(remove_branch=merge_request.force_remove_source_branch, sha=actual_sha)
+                merge_request.accept(
+                    remove_branch=merge_request.force_remove_source_branch,
+                    sha=actual_sha,
+                    merge_when_pipeline_succeeds=bool(target_project.only_allow_merge_if_pipeline_succeeds),
+                )
             except gitlab.NotAcceptable as err:
                 new_target_sha = Commit.last_on_branch(self._project.id, merge_request.target_branch, api).id
                 # target_branch has moved under us since we updated, just try again

--- a/tests/test_merge_request.py
+++ b/tests/test_merge_request.py
@@ -150,7 +150,7 @@ class TestMergeRequest:
         self.merge_request.rebase()
         self.api.call.assert_has_calls([call(req) for (req, resp) in expected])
 
-    def test_accept(self):
+    def test_accept_remove_branch(self):
         self._load(dict(INFO, sha='badc0de'))
 
         for boolean in (True, False):
@@ -165,6 +165,8 @@ class TestMergeRequest:
             ))
             self.api.call.reset_mock()
 
+    def test_accept_sha(self):
+        self._load(dict(INFO, sha='badc0de'))
         self.merge_request.accept(sha='g00dc0de')
         self.api.call.assert_called_once_with(PUT(
             '/projects/1234/merge_requests/54/merge',
@@ -172,6 +174,18 @@ class TestMergeRequest:
                 merge_when_pipeline_succeeds=True,
                 should_remove_source_branch=False,
                 sha='g00dc0de',
+            )
+        ))
+
+    def test_accept_merge_when_pipeline_succeeds(self):
+        self._load(dict(INFO, sha='badc0de'))
+        self.merge_request.accept(merge_when_pipeline_succeeds=False)
+        self.api.call.assert_called_once_with(PUT(
+            '/projects/1234/merge_requests/54/merge',
+            dict(
+                merge_when_pipeline_succeeds=False,
+                should_remove_source_branch=False,
+                sha='badc0de',
             )
         ))
 


### PR DESCRIPTION
Passing this value as True makes gitlab assume that the MR must have
a pipeline, which means if it's doesn't, then the MR will be denied.
Instead we should use the value of project.only_merge_if_pipeline_succeeds,
As this will mean the gitlab logic will be correct:
   If the MR requires a pipeline to merge then we'll only merge if a pipeline
succeeds
   If the MR doesn't needs a pipeline to succeed (i.e. has this setting on the
project off) then we won't pass the parameter and hence the merge will be allowed

Fixes issue #240