### PR TITLE
Add argument to disable fast forwarding of batch merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ optional arguments:
                            [env var: MARGE_ADD_TESTED] (default: False)
   --batch               Enable processing MRs in batches
                            [env var: MARGE_BATCH] (default: False)
+  --use-no-ff-batches      Disable fast forwarding when merging MR batches.
+                           [env var: MARGE_USE_NO_FF_BATCHES] (defualt: False)
   --add-part-of         Add "Part-of: <$MR_URL>" to each commit in MR.
                            [env var: MARGE_ADD_PART_OF] (default: False)
   --add-reviewers       Add "Reviewed-by: $approver" for each approver of MR to each commit in MR.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ optional arguments:
   --batch               Enable processing MRs in batches
                            [env var: MARGE_BATCH] (default: False)
   --use-no-ff-batches      Disable fast forwarding when merging MR batches.
-                           [env var: MARGE_USE_NO_FF_BATCHES] (defualt: False)
+                           [env var: MARGE_USE_NO_FF_BATCHES] (default: False)
   --add-part-of         Add "Part-of: <$MR_URL>" to each commit in MR.
                            [env var: MARGE_ADD_PART_OF] (default: False)
   --add-reviewers       Add "Reviewed-by: $approver" for each approver of MR to each commit in MR.

--- a/marge/app.py
+++ b/marge/app.py
@@ -208,6 +208,11 @@ def _parse_config(args):
         action='store_true',
         help='Debug logging (includes all HTTP requests etc).\n',
     )
+    parser.add_argument(
+        '--use-no-ff-batches',
+        action='store_true',
+        help='Disable fast forwarding when merging MR batches'
+    )
     config = parser.parse_args(args)
 
     if config.use_merge_strategy and config.batch:

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -114,7 +114,7 @@ class BatchMergeJob(MergeJob):
                     target_branch,
                     source_branch,
                     '--no-ff',
-                )
+            )
 
         return self._repo.fast_forward(
             target_branch,
@@ -155,9 +155,11 @@ class BatchMergeJob(MergeJob):
         self.maybe_reapprove(merge_request, approvals)
 
         # This switches git to <target_branch>
-        final_sha = self.merge_batch(merge_request.target_branch,
-                                     merge_request.source_branch,
-                                     self._options.use_no_ff_batches)
+        final_sha = self.merge_batch(
+            merge_request.target_branch,
+            merge_request.source_branch,
+            self._options.use_no_ff_batches,
+        )
 
         # Don't force push in case the remote has changed.
         self._repo.push(merge_request.target_branch, force=False)

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -108,6 +108,19 @@ class BatchMergeJob(MergeJob):
             if getattr(changed_mr, attr) != getattr(merge_request, attr):
                 raise CannotMerge(error_message.format(attr.replace('_', ' ')))
 
+    def merge_batch(self, target_branch, source_branch, no_ff=False):
+        if no_ff:
+            return self._repo.merge(
+                    target_branch,
+                    source_branch,
+                    '--no-ff',
+                )
+
+        return self._repo.fast_forward(
+            target_branch,
+            source_branch,
+        )
+
     def accept_mr(
         self,
         merge_request,
@@ -142,10 +155,9 @@ class BatchMergeJob(MergeJob):
         self.maybe_reapprove(merge_request, approvals)
 
         # This switches git to <target_branch>
-        final_sha = self._repo.fast_forward(
-            merge_request.target_branch,
-            merge_request.source_branch,
-        )
+        final_sha = self.merge_batch(merge_request.target_branch,
+                                     merge_request.source_branch,
+                                     self._options.use_no_ff_batches)
 
         # Don't force push in case the remote has changed.
         self._repo.push(merge_request.target_branch, force=False)

--- a/tests/test_batch_job.py
+++ b/tests/test_batch_job.py
@@ -138,6 +138,28 @@ class TestBatchJob:
             force=True,
         )
 
+    def test_merge_batch(self, api, mocklab):
+        batch_merge_job = self.get_batch_merge_job(api, mocklab)
+        target_branch = 'master'
+        source_branch = mocklab.merge_request_info['source_branch']
+        batch_merge_job.merge_batch(target_branch, source_branch, no_ff=False)
+        batch_merge_job._repo.fast_forward.assert_called_once_with(
+            target_branch,
+            source_branch,
+        )
+
+    def test_merge_batch_with_no_ff_enabled(self, api, mocklab):
+        batch_merge_job = self.get_batch_merge_job(api, mocklab)
+        target_branch = 'master'
+        source_branch = mocklab.merge_request_info['source_branch']
+        batch_merge_job.merge_batch(target_branch, source_branch, no_ff=True)
+        batch_merge_job._repo.merge.assert_called_once_with(
+            target_branch,
+            source_branch,
+            '--no-ff'
+        )
+        batch_merge_job._repo.fast_forward.assert_not_called()
+
     def test_ensure_mr_not_changed(self, api, mocklab):
         with patch('marge.batch_job.MergeRequest') as mr_class:
             batch_merge_job = self.get_batch_merge_job(api, mocklab)


### PR DESCRIPTION
Previously when merging batches fast forwarding is enabled. This is
problematic when reverting changes that have been fast forwarded as
you then have to revert each individual commit.

This commit adds an argument to disable the fast forward merging of
batches.

Fixes #255 