### PR TITLE
modern version of the deploy file

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -18,7 +18,7 @@ objects:
       MARGE_AUTH_TOKEN: "$(MARGE_AUTH_TOKEN)"
       MARGE_SSH_KEY: "$(MARGE_SSH_KEY)"
   - kind: Deployment
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     metadata:
       name: "$(APP_NAME)"
       namespace: "$(KUBE_NAMESPACE)"
@@ -26,6 +26,9 @@ objects:
         k8s-app: "$(APP_NAME)"
     spec:
       replicas: "$((REPLICA_COUNT))"
+      selector:
+        matchLabels:
+           k8s-app: "$(APP_NAME)"
       template:
         metadata:
           labels:


### PR DESCRIPTION
apps/v1 was introduced in 1.9

extensions/v1beta1, apps/v1beta1 and apps/v1beta2 are deprecated (and not used anymore after 1.15)

 Time to go into the future! :)