### PR TITLE
Pass use_no_ff_batches into merge options

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -311,6 +311,7 @@ def main(args=None):
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
                 fusion=fusion,
+                use_no_ff_batches=options.use_no_ff_batches,
             ),
             batch=options.batch,
         )

--- a/marge/job.py
+++ b/marge/job.py
@@ -408,6 +408,7 @@ JOB_OPTIONS = [
     'embargo',
     'ci_timeout',
     'fusion',
+    'use_no_ff_batches',
 ]
 
 
@@ -423,6 +424,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             cls, *,
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
             approval_timeout=None, embargo=None, ci_timeout=None, fusion=Fusion.rebase,
+            use_no_ff_batches=False,
     ):
         approval_timeout = approval_timeout or timedelta(seconds=0)
         embargo = embargo or IntervalUnion.empty()
@@ -436,6 +438,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             embargo=embargo,
             ci_timeout=ci_timeout,
             fusion=fusion,
+            use_no_ff_batches=use_no_ff_batches,
         )
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -200,6 +200,7 @@ class TestMergeJobOptions:
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
             fusion=Fusion.rebase,
+            use_no_ff_batches=False,
         )
 
     def test_default_ci_time(self):


### PR DESCRIPTION
#256 introduced an error where the use use_no_ff_batches option was not passed into the
options correctly. Merge options are passed into the batch job class,
and use_no_ff_batches was not included in the merge options.

Thus creating the error:
AttributeError: 'MergeJobOptions' object has no attribute 'use_no_ff_batches'

This PR adds use_no_ff_batches to the merge options.