### PR TITLE
Improve batching: allow batch MRs use merge commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ ENV/
 # nix stuff
 result
 result-*
+
+# Editor
+*.sw[po]

--- a/marge/app.py
+++ b/marge/app.py
@@ -217,7 +217,7 @@ def _parse_config(args):
         '--use-merge-commit-batches',
         action='store_true',
         help='Use merge commit when creating batches, so that the commits in the batch MR '
-             'will be the same with in individual MRs\n',
+             'will be the same with in individual MRs. Requires sudo scope in the access token.\n',
     )
     parser.add_argument(
         '--skip-ci-batches',

--- a/marge/app.py
+++ b/marge/app.py
@@ -213,6 +213,17 @@ def _parse_config(args):
         action='store_true',
         help='Disable fast forwarding when merging MR batches'
     )
+    parser.add_argument(
+        '--use-merge-commit-batches',
+        action='store_true',
+        help='Use merge commit when creating batches, so that the commits in the batch MR '
+             'will be the same with in individual MRs\n',
+    )
+    parser.add_argument(
+        '--skip-ci-batches',
+        action='store_true',
+        help='Skip CI when updating individual MRs when using batches'
+    )
     config = parser.parse_args(args)
 
     if config.use_merge_strategy and config.batch:
@@ -312,6 +323,8 @@ def main(args=None):
                 ci_timeout=options.ci_timeout,
                 fusion=fusion,
                 use_no_ff_batches=options.use_no_ff_batches,
+                use_merge_commit_batches=options.use_merge_commit_batches,
+                skip_ci_batches=options.skip_ci_batches,
             ),
             batch=options.batch,
         )

--- a/marge/approvals.py
+++ b/marge/approvals.py
@@ -51,11 +51,15 @@ class Approvals(gitlab.Resource):
         (which may invalidate approvals, depending on GitLab settings) and then
         restore the approval status.
         """
+        self.approve(self)
+
+    def approve(self, obj):
+        """Approve an object which can be a merge_request or an approval."""
         if self._api.version().release >= (9, 2, 2):
-            approve_url = '/projects/{0.project_id}/merge_requests/{0.iid}/approve'.format(self)
+            approve_url = '/projects/{0.project_id}/merge_requests/{0.iid}/approve'.format(obj)
         else:
             # GitLab botched the v4 api before 9.2.3
-            approve_url = '/projects/{0.project_id}/merge_requests/{0.id}/approve'.format(self)
+            approve_url = '/projects/{0.project_id}/merge_requests/{0.id}/approve'.format(obj)
 
         for uid in self.approver_ids:
             self._api.call(POST(approve_url), sudo=uid)

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -283,7 +283,8 @@ class BatchMergeJob(MergeJob):
                         merge_request.refetch_info()
                         tries -= 1
                     log.info(
-                        'Updated merge_request(!%s): old_sha (%s), new_sha (%s), branch sha_after_rewrite (%s)',
+                        'Updated merge_request(!%s): old_sha (%s), new_sha (%s), '
+                        'branch sha_after_rewrite (%s)',
                         merge_request.iid, _old_sha, merge_request.sha, actual_sha
                     )
 
@@ -292,7 +293,7 @@ class BatchMergeJob(MergeJob):
                     # we don't want to approve unreviewed commits
                     if merge_request.sha != actual_sha:
                         raise CannotMerge(
-                            'Someone pushed to branch while we were trying to merge, ',
+                            'Someone pushed to branch while we were trying to merge, '
                             'merge_request.sha (%s) != actual_sha (%s)' % (merge_request.sha, actual_sha)
                         )
 

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -275,27 +275,10 @@ class BatchMergeJob(MergeJob):
                 log.warning('Skipping MR !%s, got conflicts while rebasing', merge_request.iid)
                 continue
             else:
-                # update merge_request with the latest sha
                 if self._options.use_merge_commit_batches:
-                    _old_sha = merge_request.sha
-                    tries = 5
-                    while merge_request.sha == _old_sha and tries > 0:
-                        merge_request.refetch_info()
-                        tries -= 1
-                    log.info(
-                        'Updated merge_request(!%s): old_sha (%s), new_sha (%s), '
-                        'branch sha_after_rewrite (%s)',
-                        merge_request.iid, _old_sha, merge_request.sha, actual_sha
-                    )
-
-                    # Make sure no-one managed to race and push to the branch in the
-                    # meantime, because we're about to impersonate the approvers, and
-                    # we don't want to approve unreviewed commits
-                    if merge_request.sha != actual_sha:
-                        raise CannotMerge(
-                            'Someone pushed to branch while we were trying to merge, '
-                            'merge_request.sha (%s) != actual_sha (%s)' % (merge_request.sha, actual_sha)
-                        )
+                    # update merge_request with the current sha, we will compare it with
+                    # the actual sha later to make sure no one pushed this MR meanwhile
+                    merge_request.update_sha(actual_sha)
 
                 working_merge_requests.append(merge_request)
 

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -153,7 +153,7 @@ class BatchMergeJob(MergeJob):
         self,
         merge_request,
         expected_remote_target_branch_sha,
-        source_repo_url,
+        source_repo_url=None,
     ):
         log.info('Accept MR !%s', merge_request.iid)
 

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -325,9 +325,13 @@ class BatchMergeJob(MergeJob):
 
         # accept the batch MR
         if self._options.use_merge_commit_batches:
-            ret = batch_mr.accept(
-                remove_branch=batch_mr.force_remove_source_branch,
-                sha=batch_mr_sha,
-                merge_when_pipeline_succeeds=bool(self._project.only_allow_merge_if_pipeline_succeeds),
-            )
-            log.info('batch_mr.accept result: %s', ret)
+            try:
+                ret = batch_mr.accept(
+                    remove_branch=batch_mr.force_remove_source_branch,
+                    sha=batch_mr_sha,
+                    merge_when_pipeline_succeeds=bool(self._project.only_allow_merge_if_pipeline_succeeds),
+                )
+                log.info('batch_mr.accept result: %s', ret)
+            except gitlab.ApiError as e:
+                log.exception('Gitlab API Error: %s', e)
+                raise CannotMerge('Gitlab API Error: %s' % e)

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -1,8 +1,9 @@
-# pylint: disable=too-many-branches,too-many-statements
+# pylint: disable=too-many-branches,too-many-statements,arguments-differ
 import logging as log
 from time import sleep
 
 from . import git
+from . import gitlab
 from .commit import Commit
 from .job import MergeJob, CannotMerge, SkipMerge
 from .merge_request import MergeRequest
@@ -144,8 +145,9 @@ class BatchMergeJob(MergeJob):
         if sha_now != actual_sha:
             raise CannotMerge('Someone pushed to branch while we were trying to merge')
 
-        # As we're not using the API to merge the individual MR, we don't strictly need to reapprove it. However,
-        # it's a little weird to look at the merged MR to find it has no approvals, so let's do it anyway.
+        # As we're not using the API to merge the individual MR, we don't strictly need to reapprove it.
+        # However, it's a little weird to look at the merged MR to find it has no approvals,
+        # so let's do it anyway.
         self.maybe_reapprove(merge_request, approvals)
         return sha_now
 
@@ -241,7 +243,11 @@ class BatchMergeJob(MergeJob):
                         BatchMergeJob.BATCH_BRANCH_NAME,
                         merge_request.source_branch,
                         '-m',
-                        'Batch merge !%s into %s (!%s)' % (merge_request.iid, merge_request.target_branch, batch_mr.iid),
+                        'Batch merge !%s into %s (!%s)' % (
+                            merge_request.iid,
+                            merge_request.target_branch,
+                            batch_mr.iid
+                        ),
                         local=True,
                     )
                 else:
@@ -340,6 +346,6 @@ class BatchMergeJob(MergeJob):
                     merge_when_pipeline_succeeds=bool(self._project.only_allow_merge_if_pipeline_succeeds),
                 )
                 log.info('batch_mr.accept result: %s', ret)
-            except gitlab.ApiError as e:
-                log.exception('Gitlab API Error: %s', e)
-                raise CannotMerge('Gitlab API Error: %s' % e)
+            except gitlab.ApiError as err:
+                log.exception('Gitlab API Error: %s', err)
+                raise CannotMerge('Gitlab API Error: %s' % err)

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -335,7 +335,11 @@ class BatchMergeJob(MergeJob):
                 merge_request.comment("I couldn't merge this branch: %s" % err.reason)
                 raise
 
-        # accept the batch MR
+        # Approve the batch MR using the last sub MR's approvers
+        if not batch_mr.fetch_approvals().sufficient:
+            approvals = working_merge_requests[-1].fetch_approvals()
+            approvals.approve(batch_mr)
+        # Accept the batch MR
         if self._options.use_merge_commit_batches:
             try:
                 ret = batch_mr.accept(

--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -310,7 +310,8 @@ class BatchMergeJob(MergeJob):
                 # FIXME: this should probably be part of the merge request
                 _, source_repo_url, merge_request_remote = self.fetch_source_project(merge_request)
                 self.ensure_mr_not_changed(merge_request)
-                self.ensure_mergeable_mr(merge_request, skip_ci=self._options.skip_ci_batches)
+                # we know the batch MR's CI passed, so we skip CI for sub MRs this time
+                self.ensure_mergeable_mr(merge_request, skip_ci=True)
 
                 if not self._options.use_merge_commit_batches:
                     # accept each MRs

--- a/marge/git.py
+++ b/marge/git.py
@@ -129,9 +129,10 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout refere
         self.git('branch', '-D', branch)
 
     def checkout_branch(self, branch, start_point=''):
-        self.git('checkout', '-B', branch, start_point, '--')
+        create_and_reset = '-B' if start_point else ''
+        self.git('checkout', create_and_reset, branch, start_point, '--')
 
-    def push(self, branch, *, source_repo_url=None, force=False):
+    def push(self, branch, *, source_repo_url=None, force=False, skip_ci=False):
         self.git('checkout', branch, '--')
 
         self.git('diff-index', '--quiet', 'HEAD')  # check it is not dirty
@@ -146,7 +147,8 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout refere
         else:
             source = 'origin'
         force_flag = '--force' if force else ''
-        self.git('push', force_flag, source, '%s:%s' % (branch, branch))
+        skip_flag = ('-o', 'ci.skip') if skip_ci else ()
+        self.git('push', force_flag, *skip_flag, source, '%s:%s' % (branch, branch))
 
     def get_commit_hash(self, rev='HEAD'):
         """Return commit hash for `rev` (default "HEAD")."""

--- a/marge/job.py
+++ b/marge/job.py
@@ -302,20 +302,19 @@ class MergeJob:
             branch_was_modified = final_sha != initial_mr_sha
             self.synchronize_mr_with_local_changes(merge_request, branch_was_modified, source_repo_url, skip_ci=skip_ci)
         except git.GitError:
-            if not branch_update_done:
-                raise CannotMerge('got conflicts while rebasing, your problem now...')
-            if not commits_rewrite_done:
-                raise CannotMerge('failed on filter-branch; check my logs!')
-            raise
-        else:
-            return target_sha, updated_sha, final_sha
-        finally:
             # A failure to clean up probably means something is fucked with the git repo
             # and likely explains any previous failure, so it will better to just
             # raise a GitError
             if source_branch != 'master':
                 repo.checkout_branch('master')
                 repo.remove_branch(source_branch)
+
+            if not branch_update_done:
+                raise CannotMerge('got conflicts while rebasing, your problem now...')
+            if not commits_rewrite_done:
+                raise CannotMerge('failed on filter-branch; check my logs!')
+            raise
+        return target_sha, updated_sha, final_sha
 
     def synchronize_mr_with_local_changes(
         self,

--- a/marge/job.py
+++ b/marge/job.py
@@ -297,10 +297,16 @@ class MergeJob:
             target_sha = repo.get_commit_hash('origin/' + target_branch)
             if updated_sha == target_sha:
                 raise CannotMerge('these changes already exist in branch `{}`'.format(target_branch))
-            final_sha = add_trailers and self.add_trailers(merge_request) or updated_sha
+            final_sha = self.add_trailers(merge_request) if add_trailers else None
+            final_sha = final_sha or updated_sha
             commits_rewrite_done = True
             branch_was_modified = final_sha != initial_mr_sha
-            self.synchronize_mr_with_local_changes(merge_request, branch_was_modified, source_repo_url, skip_ci=skip_ci)
+            self.synchronize_mr_with_local_changes(
+                merge_request,
+                branch_was_modified,
+                source_repo_url,
+                skip_ci=skip_ci,
+            )
         except git.GitError:
             # A failure to clean up probably means something is fucked with the git repo
             # and likely explains any previous failure, so it will better to just

--- a/marge/job.py
+++ b/marge/job.py
@@ -336,12 +336,14 @@ class MergeJob:
         merge_request,
         branch_was_modified,
         source_repo_url=None,
+        skip_ci=False,
     ):
         try:
             self._repo.push(
                 merge_request.source_branch,
                 source_repo_url=source_repo_url,
                 force=True,
+                skip_ci=skip_ci,
             )
         except git.GitError:
             def fetch_remote_branch():
@@ -409,6 +411,8 @@ JOB_OPTIONS = [
     'ci_timeout',
     'fusion',
     'use_no_ff_batches',
+    'use_merge_commit_batches',
+    'skip_ci_batches',
 ]
 
 
@@ -424,7 +428,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             cls, *,
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
             approval_timeout=None, embargo=None, ci_timeout=None, fusion=Fusion.rebase,
-            use_no_ff_batches=False,
+            use_no_ff_batches=False, use_merge_commit_batches=False, skip_ci_batches=False,
     ):
         approval_timeout = approval_timeout or timedelta(seconds=0)
         embargo = embargo or IntervalUnion.empty()
@@ -439,6 +443,8 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             ci_timeout=ci_timeout,
             fusion=fusion,
             use_no_ff_batches=use_no_ff_batches,
+            use_merge_commit_batches=use_merge_commit_batches,
+            skip_ci_batches=skip_ci_batches,
         )
 
 

--- a/marge/job.py
+++ b/marge/job.py
@@ -266,6 +266,7 @@ class MergeJob:
             self,
             merge_request,
             source_repo_url=None,
+            skip_ci=False,
             add_trailers=True,
     ):
         """Updates `source_branch` on `target_branch`, optionally add trailers and push.
@@ -299,7 +300,7 @@ class MergeJob:
             final_sha = add_trailers and self.add_trailers(merge_request) or updated_sha
             commits_rewrite_done = True
             branch_was_modified = final_sha != initial_mr_sha
-            self.synchronize_mr_with_local_changes(merge_request, branch_was_modified, source_repo_url)
+            self.synchronize_mr_with_local_changes(merge_request, branch_was_modified, source_repo_url, skip_ci=skip_ci)
         except git.GitError:
             if not branch_update_done:
                 raise CannotMerge('got conflicts while rebasing, your problem now...')
@@ -321,6 +322,7 @@ class MergeJob:
         merge_request,
         branch_was_modified,
         source_repo_url=None,
+        skip_ci=False,
     ):
         if self._options.fusion is Fusion.gitlab_rebase:
             self.synchronize_using_gitlab_rebase(merge_request)
@@ -329,6 +331,7 @@ class MergeJob:
                 merge_request,
                 branch_was_modified,
                 source_repo_url=source_repo_url,
+                skip_ci=skip_ci,
             )
 
     def push_force_to_mr(

--- a/marge/job.py
+++ b/marge/job.py
@@ -265,10 +265,10 @@ class MergeJob:
     def update_from_target_branch_and_push(
             self,
             merge_request,
-            *,
             source_repo_url=None,
+            add_trailers=True,
     ):
-        """Updates `target_branch` with commits from `source_branch`, optionally add trailers and push.
+        """Updates `source_branch` on `target_branch`, optionally add trailers and push.
         The update strategy can either be rebase or merge. The default is rebase.
 
         Returns
@@ -296,7 +296,7 @@ class MergeJob:
             target_sha = repo.get_commit_hash('origin/' + target_branch)
             if updated_sha == target_sha:
                 raise CannotMerge('these changes already exist in branch `{}`'.format(target_branch))
-            final_sha = self.add_trailers(merge_request) or updated_sha
+            final_sha = add_trailers and self.add_trailers(merge_request) or updated_sha
             commits_rewrite_done = True
             branch_was_modified = final_sha != initial_mr_sha
             self.synchronize_mr_with_local_changes(merge_request, branch_was_modified, source_repo_url)

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -121,6 +121,10 @@ class MergeRequest(gitlab.Resource):
     def force_remove_source_branch(self):
         return self.info['force_remove_source_branch']
 
+    def update_sha(self, sha):
+        """record the updated sha. We don't use refetch_info instead as it may hit cache."""
+        self._info['sha'] = sha
+
     def refetch_info(self):
         self._info = self._api.call(GET('/projects/{0.project_id}/merge_requests/{0.iid}'.format(self)))
 

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -80,11 +80,12 @@ class SingleMergeJob(MergeJob):
             self.ensure_mergeable_mr(merge_request)
 
             try:
-                merge_request.accept(
+                ret = merge_request.accept(
                     remove_branch=merge_request.force_remove_source_branch,
                     sha=actual_sha,
                     merge_when_pipeline_succeeds=bool(target_project.only_allow_merge_if_pipeline_succeeds),
                 )
+                log.info('merge_request.accept result: %s', ret)
             except gitlab.NotAcceptable as err:
                 new_target_sha = Commit.last_on_branch(self._project.id, merge_request.target_branch, api).id
                 # target_branch has moved under us since we updated, just try again

--- a/pylintrc
+++ b/pylintrc
@@ -31,6 +31,8 @@ max-line-length=110
 max-args=10
 max-attributes=15
 max-public-methods=35
+# Maximum number of locals for function / method body
+max-locals=25
 
 [REPORTS]
 output-format=parseable

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -201,6 +201,8 @@ class TestMergeJobOptions:
             ci_timeout=timedelta(minutes=15),
             fusion=Fusion.rebase,
             use_no_ff_batches=False,
+            use_merge_commit_batches=False,
+            skip_ci_batches=False,
         )
 
     def test_default_ci_time(self):


### PR DESCRIPTION
Previously, we applies the commits in individual MRs to the batch MR linearly, so the commits will be rewritten and the commit sha will not be the same one passed CI, which is not good.

To make the commits be exactly the same in the individual MRs and the batch MR, I added an option to allow using merge commits in batch MRs. It acts as a helper commit in the temp branch (the batch branch) which won't affect the final merge method (we usually use the fast forwarding merge).
Besides, updating (rebase master and apply trailers) each MR before we create the batch MR to avoid rewrite commits after.

- Add `--use-merge-commit-batches` option: Use merge commit when creating batches, so that the commits in the batch MR will be the same with in individual MRs.
- Add `--skip-ci-batches` option: Skip CI when updating individual MRs when using batches. Since we have tested the batch MR, no need to run CI on individual MRs any more after we rewrite the commits.

Fixes https://github.com/smarkets/marge-bot/issues/164 https://github.com/smarkets/marge-bot/pull/252