### PR TITLE
Wait for merge status to resolve.

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -64,6 +64,10 @@ class MergeRequest(gitlab.Resource):
         return self.info['state']
 
     @property
+    def merge_status(self):
+        return self.info['merge_status']
+
+    @property
     def rebase_in_progress(self):
         return self.info.get('rebase_in_progress', False)
 

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -77,6 +77,8 @@ class SingleMergeJob(MergeJob):
                 self.wait_for_ci_to_pass(merge_request, actual_sha)
                 time.sleep(2)
 
+            self.wait_for_merge_status_to_resolve(merge_request)
+
             self.ensure_mergeable_mr(merge_request)
 
             try:

--- a/tests/gitlab_api_mock.py
+++ b/tests/gitlab_api_mock.py
@@ -50,6 +50,7 @@ class MockLab:  # pylint: disable=too-few-public-methods
             'assignees': [{'id': self.user_id}],
             'approved_by': [],
             'state': 'opened',
+            'merge_status': 'can_be_merged',
             'sha': self.commit_info['id'],
             'source_project_id': 1234,
             'target_project_id': 1234,


### PR DESCRIPTION
Closes #263 

This is a first go at a linear back-off to check whether an MR has `merge_status` set to `can_be_merged` (see the discussion on the #263).

This probably needs quite a bit more work, in particular I'm aware that I haven't made any changes to `marge/batch_job.py` or added any tests. I was a bit confused by how mocking is implemented, so I'd be grateful for some pointers if you'd like more tests. 