### PR TITLE
Add new choice assigned_at to option merge_order

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ optional arguments:
                         Marge-bot pushes effectively don't change approval status.
                            [env var: MARGE_IMPERSONATE_APPROVERS] (default: False)
   --merge-order         The order you want marge to merge its requests.
-                        As of earliest merge request creation time (created_at) or update time (updated_at)
+                        As of earliest merge request creation time (created_at), update time (updated_at)
+                        or assigned to 'marge-bot' user time (assigned_at)
                           [env var: MARGE_MERGE_ORDER] (default: created_at)
   --approval-reset-timeout APPROVAL_RESET_TIMEOUT
                         How long to wait for approvals to reset after pushing.

--- a/marge/app.py
+++ b/marge/app.py
@@ -147,8 +147,8 @@ def _parse_config(args):
     parser.add_argument(
         '--merge-order',
         default='created_at',
-        choices=('created_at', 'updated_at'),
-        help='Order marge merges assigned requests. created_at (default) or updated_at.\n',
+        choices=('created_at', 'updated_at', 'assigned_at'),
+        help='Order marge merges assigned requests. created_at (default), updated_at or assigned_at.\n',
     )
     parser.add_argument(
         '--approval-reset-timeout',

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -102,7 +102,7 @@ class Bot:
         log.info('Fetching merge requests assigned to me in %s...', project_name)
         my_merge_requests = MergeRequest.fetch_all_open_for_user(
             project_id=project.id,
-            user_id=self.user.id,
+            user=self.user,
             api=self._api,
             merge_order=self._config.merge_order,
         )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -228,10 +228,16 @@ def test_git_reference_repo():
             assert bot.config.git_reference_repo == '/foo/reference_repo'
 
 
-def test_merge_order():
+def test_merge_order_updated():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with main("--merge-order='updated_at'") as bot:
             assert bot.config.merge_order == 'updated_at'
+
+
+def test_merge_order_assigned():
+    with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
+        with main("--merge-order='assigned_at'") as bot:
+            assert bot.config.merge_order == 'assigned_at'
 
 
 # FIXME: I'd reallly prefer this to be a doctest, but adding --doctest-modules


### PR DESCRIPTION
Previously the option merge_order had two choices created_at and updated_at.
This is problematic in large projects as both options does not allow
the maintainer to control the order of merge requests.

This commit adds a new choice assigned_at to the option merge_order as
maintainers in large project often expect the order of the merge requests
related to order in which the merge requests did got assigned to the
marge-bot user.

Signed-off-by: Konrad Weihmann <konrad.weihmann@mbition.io>