### PR TITLE
Use '--rebase-merges' when rebasing

### DIFF
--- a/marge/git.py
+++ b/marge/git.py
@@ -99,7 +99,7 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout refere
 
         Throws a `GitError` if the rebase fails. Will also try to --abort it.
         """
-        return self._fuse_branch('rebase', branch, new_base, source_repo_url=source_repo_url, local=local)
+        return self._fuse_branch('rebase', branch, new_base, '--rebase-merges', source_repo_url=source_repo_url, local=local)
 
     def _fuse_branch(self, strategy, branch, target_branch, *fuse_args, source_repo_url=None, local=False):
         assert source_repo_url or branch != target_branch, branch


### PR DESCRIPTION
Avoids eliding merge commits on MR source branch. The implications of _not_ using this flag with rebase are described [in a related gitlab issue](https://gitlab.com/gitlab-org/gitaly/-/issues/3179#note_422210268):

> IMO this is a showstopping bug for the "semi-linear history" workflow with semi-long-lived feature branches, as it can lead to accidental data loss (because Gitlab encodes important information in merge commit messages). I'd really like to see the default behavior change to --rebase-merges, and I hope the severity of this issue can be recognized and the fix prioritized accordingly.

Not tested yet; I was going to first see if there were CI tests.