### PR TITLE
Fixed a bug which prevented marge batch merging with fast forward commits

### DIFF
--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -262,7 +262,7 @@ class BatchMergeJob(MergeJob):
                         local=True,
                     )
                     # Update <batch> branch with MR changes
-                    self._repo.fast_forward(
+                    batch_mr_sha = self._repo.fast_forward(
                         BatchMergeJob.BATCH_BRANCH_NAME,
                         merge_request.source_branch,
                         local=True,


### PR DESCRIPTION
fix(BatchMergeRequest): fixed a bug which prevented marge batch merging with fast forward commits

batch_mr_sha was not set when fast forward merging