### PR TITLE
implement HTTPS support for cloning (#225)

### DIFF
--- a/dockerize.nix
+++ b/dockerize.nix
@@ -31,9 +31,10 @@ in
         busybox
         gitMinimal
         openssh
+        cacert
       ] ++ [ marge ];
     config = {
       Entrypoint = [ "/bin/marge.app" ];
-      Env = ["LANG=en_US.UTF-8" ''LOCALE_ARCHIVE=/lib/locale/locale-archive''];
+      Env = ["LANG=en_US.UTF-8" ''LOCALE_ARCHIVE=/lib/locale/locale-archive'' "GIT_SSL_CAINFO=/etc/ssl/certs/ca-bundle.crt" "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"];
     };
   }

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -32,13 +32,22 @@ class Bot:
 
     def start(self):
         with TemporaryDirectory() as root_dir:
-            repo_manager = store.RepoManager(
-                user=self.user,
-                root_dir=root_dir,
-                ssh_key_file=self._config.ssh_key_file,
-                timeout=self._config.git_timeout,
-                reference=self._config.git_reference_repo,
-            )
+            if self._config.use_https:
+                repo_manager = store.HttpsRepoManager(
+                    user=self.user,
+                    root_dir=root_dir,
+                    auth_token=self._config.auth_token,
+                    timeout=self._config.git_timeout,
+                    reference=self._config.git_reference_repo,
+                )
+            else:
+                repo_manager = store.SshRepoManager(
+                    user=self.user,
+                    root_dir=root_dir,
+                    ssh_key_file=self._config.ssh_key_file,
+                    timeout=self._config.git_timeout,
+                    reference=self._config.git_reference_repo,
+                )
             self._run(repo_manager)
 
     @property
@@ -189,8 +198,8 @@ class Bot:
 
 
 class BotConfig(namedtuple('BotConfig',
-                           'user ssh_key_file project_regexp merge_order merge_opts git_timeout ' +
-                           'git_reference_repo branch_regexp source_branch_regexp batch cli')):
+                           'user use_https auth_token ssh_key_file project_regexp merge_order merge_opts ' +
+                           'git_timeout git_reference_repo branch_regexp source_branch_regexp batch cli')):
     pass
 
 

--- a/marge/project.py
+++ b/marge/project.py
@@ -78,6 +78,10 @@ class Project(gitlab.Resource):
         return self.info['ssh_url_to_repo']
 
     @property
+    def http_url_to_repo(self):
+        return self.info['http_url_to_repo']
+
+    @property
     def merge_requests_enabled(self):
         return self.info['merge_requests_enabled']
 

--- a/marge/store.py
+++ b/marge/store.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 
 from . import git
@@ -5,13 +6,30 @@ from . import git
 
 class RepoManager:
 
-    def __init__(self, user, root_dir, ssh_key_file=None, timeout=None, reference=None):
+    def __init__(self, user, root_dir, timeout=None, reference=None):
         self._root_dir = root_dir
         self._user = user
-        self._ssh_key_file = ssh_key_file
         self._repos = {}
         self._timeout = timeout
         self._reference = reference
+
+    def forget_repo(self, project):
+        self._repos.pop(project.id, None)
+
+    @property
+    def user(self):
+        return self._user
+
+    @property
+    def root_dir(self):
+        return self._root_dir
+
+
+class SshRepoManager(RepoManager):
+
+    def __init__(self, user, root_dir, ssh_key_file=None, timeout=None, reference=None):
+        super().__init__(user, root_dir, timeout, reference)
+        self._ssh_key_file = ssh_key_file
 
     def repo_for_project(self, project):
         repo = self._repos.get(project.id)
@@ -31,17 +49,39 @@ class RepoManager:
 
         return repo
 
-    def forget_repo(self, project):
-        self._repos.pop(project.id, None)
-
-    @property
-    def user(self):
-        return self._user
-
-    @property
-    def root_dir(self):
-        return self._root_dir
-
     @property
     def ssh_key_file(self):
         return self._ssh_key_file
+
+
+class HttpsRepoManager(RepoManager):
+
+    def __init__(self, user, root_dir, auth_token=None, timeout=None, reference=None):
+        super().__init__(user, root_dir, timeout, reference)
+        self._auth_token = auth_token
+
+    def repo_for_project(self, project):
+        repo = self._repos.get(project.id)
+        if not repo or repo.remote_url != project.http_url_to_repo:
+            credentials = "oauth2:" + self._auth_token
+            # insert token auth "oauth2:<auth_token>@"
+            pattern = "(http(s)?://)"
+            replacement = r"\1" + credentials + "@"
+            repo_url = re.sub(pattern, replacement, project.http_url_to_repo, 1)
+            local_repo_dir = tempfile.mkdtemp(dir=self._root_dir)
+
+            repo = git.Repo(repo_url, local_repo_dir, ssh_key_file=None,
+                            timeout=self._timeout, reference=self._reference)
+            repo.clone()
+            repo.config_user_info(
+                user_email=self._user.email,
+                user_name=self._user.name,
+            )
+
+            self._repos[project.id] = repo
+
+        return repo
+
+    @property
+    def auth_token(self):
+        return self._auth_token

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -18,7 +18,7 @@ class TestRepoManager:
     def setup_method(self, _method):
         user = marge.user.User(api=None, info=dict(USER_INFO, name='Peter Parker', email='pparker@bugle.com'))
         self.root_dir = tempfile.TemporaryDirectory()
-        self.repo_manager = marge.store.RepoManager(
+        self.repo_manager = marge.store.SshRepoManager(
             user=user, root_dir=self.root_dir.name, ssh_key_file='/ssh/key',
         )
 


### PR DESCRIPTION
I finally found some time to implement this. I took @flaviouk idea and added a compatible argument parsing around it.
This is my first python project so I would love to get honest feedback, about parts that can be improved.

How do you like the idea of the mutally exclusive argument group of https vs. ssh?

Changes
* added configuration for HTTP(S) support
* added / configured cacerts nix package to allow SSL validation
* updated usage in Readme with latest `--help` output
* addded help section in Readme for configuring HTTP(S)