### PR TITLE
Allow running marge-bot in CI pipelines or as a single CLI job

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ optional arguments:
                            [env var: MARGE_SOURCE_BRANCH_REGEXP] (default: .*)
   --debug               Debug logging (includes all HTTP requests etc).
                            [env var: MARGE_DEBUG] (default: False)
+  --cli                 Run marge-bot as a single CLI command, not as a long-running service.
+                        This may be used to run marge-bot in scheduled CI pipelines or cronjobs.
+                           [env var: MARGE_CLI] (default: False)
 ```
 Here is a config file example
 ```yaml
@@ -297,6 +300,43 @@ configs:
   marge_bot_config:
     file: ./marge-bot-config.yaml
     name: marge_bot_config
+```
+
+### Running marge-bot in CI
+
+You can also run marge-bot directly in your existing CI via scheduled pipelines
+if you'd like to avoid setting up any additional infrastructure.
+
+This way, you can inject secrets for marge-bot's credentials at runtime
+inside the ephemeral container for each run by adding them to protected CI/CD
+variables in a dedicated marge-bot runner project, as well as store execution
+logs as artifacts for evidence.
+
+You can also configure multiple setups in different CI schedules by supplying
+`MARGE_*` environment variables per-schedule, such as running a different set
+of projects or settings at different times.
+
+Note that in this case, marge-bot will be slower than when run as a service,
+depending on the frequency of your pipeline schedules.
+
+Create a marge-bot runner project, and add the variables `MARGE_AUTH_TOKEN`
+(of type Variable) and `MARGE_SSH_KEY_FILE` (of type File) in your CI/CD
+Variables settings.
+
+Then add a scheduled pipeline run to your project with the following minimal
+`.gitlab-ci.yml` config:
+
+```yaml
+run:
+  image:
+    name: smarkets/marge-bot:latest
+    entrypoint: [""]
+  only:
+    - schedules
+  variables:
+    MARGE_CLI: "true"
+    MARGE_GITLAB_URL: "$CI_SERVER_URL"
+  script: marge.app
 ```
 
 ### Running marge-bot as a plain python app

--- a/marge/app.py
+++ b/marge/app.py
@@ -224,6 +224,11 @@ def _parse_config(args):
         action='store_true',
         help='Skip CI when updating individual MRs when using batches'
     )
+    parser.add_argument(
+        '--cli',
+        action='store_true',
+        help='Run marge-bot as a single CLI command, not a service'
+    )
     config = parser.parse_args(args)
 
     if config.use_merge_strategy and config.batch:
@@ -327,6 +332,7 @@ def main(args=None):
                 skip_ci_batches=options.skip_ci_batches,
             ),
             batch=options.batch,
+            cli=options.cli,
         )
 
         marge_bot = bot.Bot(api=api, config=config)

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -59,6 +59,9 @@ class Bot:
                 time_to_sleep_between_projects_in_secs,
                 projects,
             )
+            if self._config.cli:
+                return
+
             big_sleep = max(0,
                             min_time_to_sleep_after_iterating_all_projects_in_secs -
                             time_to_sleep_between_projects_in_secs * len(projects))
@@ -187,7 +190,7 @@ class Bot:
 
 class BotConfig(namedtuple('BotConfig',
                            'user ssh_key_file project_regexp merge_order merge_opts git_timeout ' +
-                           'git_reference_repo branch_regexp source_branch_regexp batch')):
+                           'git_reference_repo branch_regexp source_branch_regexp batch cli')):
     pass
 
 


### PR DESCRIPTION
This PR allows running marge-bot as a single job rather than looping indefinitely, so it can be managed via CI pipeline schedules instead of deploying it to your infrastructure.

See also renovate-bot's approach for something similar. https://docs.renovatebot.com/self-hosting/#gitlab-cicd-pipeline

I've added this as a simple flag since I wanted to keep codebase change to a minimum, although I was initially considering another `console_scripts` entrypoint. But I didn't want to change your approach to deployment too much (see also https://github.com/smarkets/marge-bot/issues/288) so I hope this is fine.

I also considered auto-detecting/defaulting to the `GITLAB_CI` and `CI_SERVER_URL` (for `gitlab_url`) env vars if marge detects it's in a CI environment, to get a bit closer to zero-config. But I also didn't want to break the existing response to required args. It's tempting though, let me know if you'd accept that :)

For an example run, see https://gitlab.com/nejch1/test-marge-bot-as-ci-service/-/jobs/1029017409.