### PR TITLE
AccessLevel enum matches GitLab docs

### DIFF
--- a/marge/project.py
+++ b/marge/project.py
@@ -108,8 +108,10 @@ class Project(gitlab.Resource):
 @unique
 class AccessLevel(IntEnum):
     # See https://docs.gitlab.com/ce/api/access_requests.html
+    none = 0
+    minimal = 5
     guest = 10
     reporter = 20
     developer = 30
-    master = 40
+    maintainer = 40
     owner = 50


### PR DESCRIPTION
Valid access levels, according to:

https://docs.gitlab.com/ce/api/access_requests.html

are currently:

* No access (0)
* Minimal access (5) (Introduced in GitLab 13.5.)
* Guest (10)
* Reporter (20)
* Developer (30)
* Maintainer (40)
* Owner (50) - Only valid to set for groups

This commit ensures that the enum matches the docs.
This is a follow-up to PR #279 -- sorry I missed this one at the time!