### PR TITLE
batch mode for forked project

### DIFF
--- a/marge/batch_job.py
+++ b/marge/batch_job.py
@@ -110,17 +110,20 @@ class BatchMergeJob(MergeJob):
             if getattr(changed_mr, attr) != getattr(merge_request, attr):
                 raise CannotMerge(error_message.format(attr.replace('_', ' ')))
 
-    def merge_batch(self, target_branch, source_branch, no_ff=False):
+    def merge_batch(self, target_branch, source_branch, no_ff=False, source_repo_url=None, local=False):
         if no_ff:
             return self._repo.merge(
-                    target_branch,
-                    source_branch,
-                    '--no-ff',
+                target_branch,
+                source_branch,
+                '--no-ff',
+                source_repo_url,
+                local
             )
-
         return self._repo.fast_forward(
             target_branch,
             source_branch,
+            source_repo_url,
+            local
         )
 
     def update_merge_request(
@@ -177,6 +180,8 @@ class BatchMergeJob(MergeJob):
             merge_request.target_branch,
             merge_request.source_branch,
             self._options.use_no_ff_batches,
+            source_repo_url,
+            merge_request.source_project_id == merge_request.source_project_id
         )
         # Don't force push in case the remote has changed.
         self._repo.push(merge_request.target_branch, force=False)


### PR DESCRIPTION
When source project is not the same main project, such as  forked project, It cannot merged in batch mode when git merge command executes.
I tested on 0.9.4 version in gitlab before.  I hope this may  help someone.
The errors in stderr as follows,
```
2021-02-09 23:35:12,133 INFO Running git -C /tmp69xfoh8v/tmpq_9azzie merge origin/ark_region_fix --ff --ff-only
2021-02-09 23:35:12,142 WARNING git returned 1
2021-02-09 23:35:12,142 WARNING stdout: b''
2021-02-09 23:35:12,142 WARNING stderr: b'merge: origin/ark_region_fix - not something we can merge\n'
2021-02-09 23:35:12,142 WARNING merge failed, doing an --abort
2021-02-09 23:35:12,142 INFO Running git -C /tmp69xfoh8v/tmpq_9azzie merge --abort
2021-02-09 23:35:12,146 WARNING git returned 128
2021-02-09 23:35:12,146 WARNING stdout: b''
2021-02-09 23:35:12,146 WARNING stderr: b'fatal: There is no merge to abort (MERGE_HEAD missing).\n'
2021-02-09 23:35:12,146 ERROR BatchMergeJob failed: Command '[b'git', b'-C', b'/tmp69xfoh8v/tmpq_9azzie', b'merge', b'--abort']' returned non-zero exit status 128.
Traceback (most recent call last):
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/git.py", line 185, in git
    return _run(*command, env=env, check=True, timeout=timeout_seconds)
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/git.py", line 211, in _run
    retcode, process.args, output=stdout, stderr=stderr,
subprocess.CalledProcessError: Command '[b'git', b'-C', b'/tmp69xfoh8v/tmpq_9azzie', b'merge', b'origin/ark_region_fix', b'--ff', b'--ff-only']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/git.py", line 120, in _fuse_branch
    self.git(strategy, target, *fuse_args)
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/git.py", line 190, in git
    raise GitError(err)
marge.git.GitError: Command '[b'git', b'-C', b'/tmp69xfoh8v/tmpq_9azzie', b'merge', b'origin/ark_region_fix', b'--ff', b'--ff-only']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/git.py", line 185, in git
    return _run(*command, env=env, check=True, timeout=timeout_seconds)
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/git.py", line 211, in _run
    retcode, process.args, output=stdout, stderr=stderr,
subprocess.CalledProcessError: Command '[b'git', b'-C', b'/tmp69xfoh8v/tmpq_9azzie', b'merge', b'--abort']' returned non-zero exit status 128.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/bot.py", line 160, in _process_merge_requests
    batch_merge_job.execute()
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/batch_job.py", line 321, in execute
    source_repo_url=source_repo_url,
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/batch_job.py", line 179, in accept_mr
    self._options.use_no_ff_batches,
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/batch_job.py", line 123, in merge_batch
    self.git(strategy, '--abort')
  File "/nix/store/vn94z48nxysnirpx7pkqacygmkgr1q18-python3.6-marge-0.9.4/lib/python3.6/site-packages/marge/git.py", line 190, in git
    raise GitError(err)
marge.git.GitError: Command '[b'git', b'-C', b'/tmp69xfoh8v/tmpq_9azzie', b'merge', b'--abort']' returned non-zero exit status 128.
```