### PR TITLE
Report unresolved discussions to the user

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -55,6 +55,9 @@ class MergeJob:
                 '(have: {0.approver_usernames} missing: {0.approvals_left})'.format(approvals)
             )
 
+        if not merge_request.blocking_discussions_resolved:
+            raise CannotMerge("Sorry, I can't merge requests which have unresolved discussions!")
+
         state = merge_request.state
         if state not in ('opened', 'reopened', 'locked'):
             if state in ('merged', 'closed'):

--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -152,6 +152,10 @@ class MergeRequest(gitlab.Resource):
         return self.info['web_url']
 
     @property
+    def blocking_discussions_resolved(self):
+        return self.info['blocking_discussions_resolved']
+
+    @property
     def force_remove_source_branch(self):
         return self.info['force_remove_source_branch']
 

--- a/tests/gitlab_api_mock.py
+++ b/tests/gitlab_api_mock.py
@@ -58,6 +58,7 @@ class MockLab:  # pylint: disable=too-few-public-methods
             'force_remove_source_branch': True,
             'target_branch': 'master',
             'work_in_progress': False,
+            'blocking_discussions_resolved': True,
             'web_url': 'http://git.example.com/group/project/merge_request/666',
         }
         if merge_request_options is not None:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -130,6 +130,20 @@ class TestJob:
 
         assert exc_info.value.reason == "Sorry, I can't merge requests marked as Work-In-Progress!"
 
+    def test_ensure_mergeable_mr_unresolved_discussion(self):
+        merge_job = self.get_merge_job()
+        merge_request = self._mock_merge_request(
+            assignee_ids=[merge_job._user.id],
+            state='opened',
+            work_in_progress=False,
+            blocking_discussions_resolved=False,
+        )
+        merge_request.fetch_approvals.return_value.sufficient = True
+        with pytest.raises(CannotMerge) as exc_info:
+            merge_job.ensure_mergeable_mr(merge_request)
+
+        assert exc_info.value.reason == "Sorry, I can't merge requests which have unresolved discussions!"
+
     def test_ensure_mergeable_mr_squash_and_trailers(self):
         merge_job = self.get_merge_job(options=MergeJobOptions.default(add_reviewers=True))
         merge_request = self._mock_merge_request(


### PR DESCRIPTION
Resolves #317

Gives a nicer error message to the user if an MR cannot be merged due to unresolved discussions. 