### PR TITLE
Use ci_timeout for merging

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -22,7 +22,7 @@ class MergeJob:
         self._project = project
         self._repo = repo
         self._options = options
-        self._merge_timeout = timedelta(minutes=5)
+        self._merge_timeout = options.ci_timeout
 
     @property
     def repo(self):


### PR DESCRIPTION
When the bot is waiting for "merge when pipeline suceeds"
the hardcoded 5 minute timeout was applied.

We need to wait for CI to finish in this case,
so setting the merge timeout to CI timeout.