### PR TITLE
Ignore jobs with manual trigger in CI

### DIFF
--- a/marge/job.py
+++ b/marge/job.py
@@ -182,7 +182,7 @@ class MergeJob:
             if ci_status == 'skipped':
                 log.info('CI for MR !%s skipped', merge_request.iid)
                 return
-            
+
             if ci_status == 'manual':
                 log.info('CI for MR !%s has manual jobs', merge_request.iid)
                 return

--- a/marge/job.py
+++ b/marge/job.py
@@ -182,6 +182,10 @@ class MergeJob:
             if ci_status == 'skipped':
                 log.info('CI for MR !%s skipped', merge_request.iid)
                 return
+            
+            if ci_status == 'manual':
+                log.info('CI for MR !%s has manual jobs', merge_request.iid)
+                return
 
             if ci_status == 'failed':
                 raise CannotMerge('CI failed!')


### PR DESCRIPTION
Marge bot gets stuck when there are manual jobs pending in CI.  
This PR assumes they are not necessary for a MR to be merged and considers the "manual" CI status as a valid status for merge.