### PR TITLE
Handle when marge is assigned to a MR who's Vulnerability-Check has not completed yet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ optional arguments:
                         Use merge commit when creating batches, so that the commits in the batch MR will be the same with in individual MRs. Requires sudo scope in the access token.
                            [env var: MARGE_USE_MERGE_COMMIT_BATCHES] (default: False)
   --skip-ci-batches     Skip CI when updating individual MRs when using batches   [env var: MARGE_SKIP_CI_BATCHES] (default: False)
+  --wait-for-sast       Marge will wait for SAST CI jobs to complete before trying to merge [env var: WAIT_FOR_SAST] (default: False)
 ```
 Here is a config file example
 ```yaml

--- a/marge/app.py
+++ b/marge/app.py
@@ -233,6 +233,12 @@ def _parse_config(args):
         help='Skip CI when updating individual MRs when using batches'
     )
     parser.add_argument(
+        '--wait-for-sast',
+        env_var='WAIT_FOR_SAST',
+        action='store_true',
+        help='Wait for SAST jobs to complete before trying to merge'
+    )
+    parser.add_argument(
         '--cli',
         action='store_true',
         help='Run marge-bot as a single CLI command, not a service'
@@ -342,6 +348,7 @@ def main(args=None):
                 use_no_ff_batches=options.use_no_ff_batches,
                 use_merge_commit_batches=options.use_merge_commit_batches,
                 skip_ci_batches=options.skip_ci_batches,
+                wait_for_sast=options.wait_for_sast,
             ),
             batch=options.batch,
             cli=options.cli,

--- a/marge/approvals.py
+++ b/marge/approvals.py
@@ -40,6 +40,10 @@ class Approvals(gitlab.Resource):
         return [who['user']['username'] for who in self.info['approved_by']]
 
     @property
+    def approval_rules_left(self):
+        return [rule['name'] for rule in self.info['approval_rules_left']]
+
+    @property
     def approver_ids(self):
         """Return the uids of the approvers."""
         return [who['user']['id'] for who in self.info['approved_by']]

--- a/marge/job.py
+++ b/marge/job.py
@@ -460,6 +460,7 @@ JOB_OPTIONS = [
     'use_no_ff_batches',
     'use_merge_commit_batches',
     'skip_ci_batches',
+    'wait_for_sast',
 ]
 
 
@@ -474,8 +475,9 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
     def default(
             cls, *,
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
-            approval_timeout=None, embargo=None, ci_timeout=None, fusion=Fusion.rebase,
-            use_no_ff_batches=False, use_merge_commit_batches=False, skip_ci_batches=False,
+            approval_timeout=None, embargo=None, ci_timeout=None, wait_for_sast=False,
+            fusion=Fusion.rebase, use_no_ff_batches=False, use_merge_commit_batches=False,
+            skip_ci_batches=False,
     ):
         approval_timeout = approval_timeout or timedelta(seconds=0)
         embargo = embargo or IntervalUnion.empty()
@@ -488,6 +490,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             approval_timeout=approval_timeout,
             embargo=embargo,
             ci_timeout=ci_timeout,
+            wait_for_sast=wait_for_sast,
             fusion=fusion,
             use_no_ff_batches=use_no_ff_batches,
             use_merge_commit_batches=use_merge_commit_batches,

--- a/tests/test_approvals.py
+++ b/tests/test_approvals.py
@@ -43,7 +43,8 @@ INFO = {
                 "state": "active",
             }
         }
-    ]
+    ],
+    'approval_rules_left': [],
 }
 USERS = {
     1: {

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -213,6 +213,7 @@ class TestMergeJobOptions:
             approval_timeout=timedelta(seconds=0),
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
+            wait_for_sast=False,
             fusion=Fusion.rebase,
             use_no_ff_batches=False,
             use_merge_commit_batches=False,


### PR DESCRIPTION
On our GitLab instance we are using SAST and use the Vulnerability-Check group that GitLab creates from using SAST.

We have noticed that sometimes a developer will assign a merge request to marge-bot and marge-bot will report:
`I couldn't merge this branch: Insufficient approvals (have: ['joeuser'] missing: 1)`

marge-bot will only report this if SAST checks are running. The developer has to wait for SAST checks to complete and then assign it to marge-bot again.

If SAST checks complete in time and are passing marge-bot will merge the merge request no problem. This feels like a race-condition.

It would be nice if marge-bot had this ability to wait for Vulnerability-Checks.