### PR TITLE
Use `--rebase-merges` when rebasing

### DIFF
--- a/marge/git.py
+++ b/marge/git.py
@@ -99,7 +99,8 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout refere
 
         Throws a `GitError` if the rebase fails. Will also try to --abort it.
         """
-        return self._fuse_branch('rebase', branch, new_base, '--rebase-merges', source_repo_url=source_repo_url, local=local)
+        return self._fuse_branch('rebase', branch, new_base, '--rebase-merges',
+                                 source_repo_url=source_repo_url, local=local)
 
     def _fuse_branch(self, strategy, branch, target_branch, *fuse_args, source_repo_url=None, local=False):
         assert source_repo_url or branch != target_branch, branch

--- a/marge/git.py
+++ b/marge/git.py
@@ -99,7 +99,7 @@ class Repo(namedtuple('Repo', 'remote_url local_path ssh_key_file timeout refere
 
         Throws a `GitError` if the rebase fails. Will also try to --abort it.
         """
-        return self._fuse_branch('rebase', branch, new_base, source_repo_url=source_repo_url, local=local)
+        return self._fuse_branch('rebase', branch, new_base, '--rebase-merges', source_repo_url=source_repo_url, local=local)
 
     def _fuse_branch(self, strategy, branch, target_branch, *fuse_args, source_repo_url=None, local=False):
         assert source_repo_url or branch != target_branch, branch

--- a/tests/git_repo_mock.py
+++ b/tests/git_repo_mock.py
@@ -162,8 +162,8 @@ class GitModel:
         remote, branch = arg.split('/')
         return self._remote_refs[remote].get_ref(branch)
 
-    def rebase(self, arg):
-        remote, branch = arg.split('/')
+    def rebase(self, *args):
+        remote, branch = args[0].split('/')
         new_base = self._remote_refs[remote].get_ref(branch)
         if new_base != self._head:
             new_sha = 'rebase(%s onto %s)' % (self._head, new_base)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -43,7 +43,7 @@ class TestRepo:
         assert get_calls(mocked_run) == [
             'git -C /tmp/local/path fetch --prune origin',
             'git -C /tmp/local/path checkout -B feature_branch origin/feature_branch --',
-            'git -C /tmp/local/path rebase origin/master_of_the_universe',
+            'git -C /tmp/local/path rebase origin/master_of_the_universe --rebase-merges',
             'git -C /tmp/local/path rev-parse HEAD'
         ]
 


### PR DESCRIPTION
Pick patch from #274 & fix unittests

This patch is useful in limitted environments.
For example, if a project uses the `subtree`, `rebase` command will break directory structure.
(`subtree` will make the patchset in same as original repo tree then move the directory in `merge` commit.)

I just checked that this patch is keepping `merge` commits.
 
Related #280 