### PR TITLE
Fix rebasing through GitLab's api

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -164,7 +164,10 @@ class MergeRequest(gitlab.Resource):
         self._info['sha'] = sha
 
     def refetch_info(self):
-        self._info = self._api.call(GET('/projects/{0.project_id}/merge_requests/{0.iid}'.format(self)))
+        self._info = self._api.call(GET(
+            '/projects/{0.project_id}/merge_requests/{0.iid}'.format(self),
+            {'include_rebase_in_progress': 'true'}
+        ))
 
     def comment(self, message):
         if self._api.version().release >= (9, 2, 2):

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -60,7 +60,10 @@ class SingleMergeJob(MergeJob):
                 )
             except GitLabRebaseResultMismatch:
                 if first_iteration:
-                    log.info("Gitlab rebase didn't give expected result. Expected immediately after rebase. Retrying.")
+                    log.info(
+                        "Gitlab rebase didn't give expected result."
+                        "This is expected immediately after rebase. Retrying."
+                    )
                     first_iteration = False
                 else:
                     log.info("Gitlab rebase didn't give expected result")

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -45,6 +45,7 @@ class SingleMergeJob(MergeJob):
         api = self._api
         merge_request = self._merge_request
         updated_into_up_to_date_target_branch = False
+        first_iteration = True
 
         while not updated_into_up_to_date_target_branch:
             self.ensure_mergeable_mr(merge_request)
@@ -58,8 +59,12 @@ class SingleMergeJob(MergeJob):
                     source_repo_url=source_repo_url,
                 )
             except GitLabRebaseResultMismatch:
-                log.info("Gitlab rebase didn't give expected result")
-                merge_request.comment("Someone skipped the queue! Will have to try again...")
+                if first_iteration:
+                    log.info("Gitlab rebase didn't give expected result. Expected immediately after rebase. Retrying.")
+                    first_iteration = False
+                else:
+                    log.info("Gitlab rebase didn't give expected result")
+                    merge_request.comment("Someone skipped the queue! Will have to try again...")
                 continue
 
             if _updated_sha == actual_sha and self._options.guarantee_final_pipeline:

--- a/tests/gitlab_api_mock.py
+++ b/tests/gitlab_api_mock.py
@@ -175,6 +175,14 @@ class Api(gitlab.Api):
 
     def add_merge_request(self, info, sudo=None, from_state=None, to_state=None):
         self.add_resource('/projects/{0.project_id}/merge_requests/{0.iid}', info, sudo, from_state, to_state)
+        self.add_transition(
+            GET(
+                '/projects/{0.project_id}/merge_requests/{0.iid}'.format(attrs(info)),
+                args={'include_rebase_in_progress': 'true'},
+            ),
+            Ok(info),
+            sudo, from_state, to_state,
+        )
 
     def add_commit(self, project_id, info, sudo=None, from_state=None, to_state=None):
         path = '/projects/%s/repository/commits/{0.id}' % project_id

--- a/tests/test_merge_request.py
+++ b/tests/test_merge_request.py
@@ -50,7 +50,12 @@ class TestMergeRequest:
 
         merge_request = MergeRequest.fetch_by_iid(project_id=1234, merge_request_iid=54, api=api)
 
-        api.call.assert_called_once_with(GET('/projects/1234/merge_requests/54'))
+        api.call.assert_called_once_with(
+            GET(
+                '/projects/1234/merge_requests/54',
+                {'include_rebase_in_progress': 'true'}
+            )
+        )
         assert merge_request.info == INFO
 
     def test_refetch_info(self):
@@ -58,7 +63,12 @@ class TestMergeRequest:
         self.api.call = Mock(return_value=new_info)
 
         self.merge_request.refetch_info()
-        self.api.call.assert_called_once_with(GET('/projects/1234/merge_requests/54'))
+        self.api.call.assert_called_once_with(
+            GET(
+                '/projects/1234/merge_requests/54',
+                {'include_rebase_in_progress': 'true'}
+            )
+        )
         assert self.merge_request.info == new_info
 
     def test_properties(self):
@@ -99,7 +109,10 @@ class TestMergeRequest:
     def test_rebase_was_not_in_progress_no_error(self):
         expected = [
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> not in progress
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> not in progress
                 INFO
             ),
             (
@@ -107,11 +120,18 @@ class TestMergeRequest:
                 True
             ),
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> in progress
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> in progress
                 dict(INFO, rebase_in_progress=True)
             ),
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> succeeded
+                # GET('/projects/1234/merge_requests/54'),  # refetch_info -> succeeded
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> succeeded
                 dict(INFO, rebase_in_progress=False)
             ),
         ]
@@ -123,7 +143,10 @@ class TestMergeRequest:
     def test_rebase_was_not_in_progress_error(self):
         expected = [
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> not in progress
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> not in progress
                 INFO
             ),
             (
@@ -131,7 +154,10 @@ class TestMergeRequest:
                 True
             ),
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> BOOM
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> BOOM
                 dict(INFO, rebase_in_progress=False, merge_error="Rebase failed. Please rebase locally")
             ),
         ]
@@ -145,15 +171,24 @@ class TestMergeRequest:
     def test_rebase_was_in_progress_no_error(self):
         expected = [
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> in progress
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> in progress
                 dict(INFO, rebase_in_progress=True)
             ),
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> in progress
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> in progress
                 dict(INFO, rebase_in_progress=True)
             ),
             (
-                GET('/projects/1234/merge_requests/54'),  # refetch_info -> succeeded
+                GET(
+                    '/projects/1234/merge_requests/54',
+                    {'include_rebase_in_progress': 'true'}
+                ),  # refetch_info -> succeeded
                 dict(INFO, rebase_in_progress=False)
             ),
         ]
@@ -232,5 +267,10 @@ class TestMergeRequest:
         old_mock = self.api.call
         self.api.call = Mock(return_value=json)
         self.merge_request.refetch_info()
-        self.api.call.assert_called_with(GET('/projects/1234/merge_requests/54'))
+        self.api.call.assert_called_with(
+            GET(
+                '/projects/1234/merge_requests/54',
+                {'include_rebase_in_progress': 'true'}
+            )
+        )
         self.api.call = old_mock


### PR DESCRIPTION
Fixes race conditions by providing `include_rebase_in_progress` parameter as noted in https://github.com/smarkets/marge-bot/pull/160#issuecomment-763628397.  
Also, prevents marge-bot to not complain abount someone skipping the queue on each merge requests as noted in https://github.com/smarkets/marge-bot/pull/160#issuecomment-482013649 and in https://github.com/smarkets/marge-bot/issues/337