### PR TITLE
Fix tests by adding pip constraint for importlib-metadata.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements
-        run: pip install -r requirements_frozen.txt
+        run: pip install -c constraints.txt -r requirements_frozen.txt
       - name: Run tests
         run: pytest

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+importlib-metadata<5.0


### PR DESCRIPTION
The tests workflow currently fails on `master`.

See https://stackoverflow.com/a/73932581. It seems like `importlib-metadata` is only required for tests, not production code.