### PR TITLE
Verify that user who assigned us is allowed to merge

### DIFF
--- a/marge/member.py
+++ b/marge/member.py
@@ -1,0 +1,16 @@
+from . import gitlab
+
+
+GET = gitlab.GET
+
+
+class Member(gitlab.Resource):
+
+    @classmethod
+    def fetch_by_id(cls, project_id, member_id, api):
+        info = api.call(GET('/projects/%s/members/%s' % (project_id, member_id)))
+        return cls(api, info)
+
+    @property
+    def access_level(self):
+        return self.info['access_level']

--- a/marge/member.py
+++ b/marge/member.py
@@ -8,7 +8,7 @@ class Member(gitlab.Resource):
 
     @classmethod
     def fetch_by_id(cls, project_id, member_id, api):
-        info = api.call(GET('/projects/%s/members/%s' % (project_id, member_id)))
+        info = api.call(GET('/projects/%s/members/all/%s' % (project_id, member_id)))
         return cls(api, info)
 
     @property

--- a/marge/protected_branch.py
+++ b/marge/protected_branch.py
@@ -1,0 +1,21 @@
+import sys
+from . import gitlab
+
+
+GET = gitlab.GET
+
+
+class ProtectedBranch(gitlab.Resource):
+
+    @classmethod
+    def fetch_by_name(cls, project_id, branch_name, api):
+        info = api.call(GET('/projects/%s/protected_branches/%s' % (project_id, branch_name)))
+        return cls(api, info)
+
+    @property
+    def merge_min_access_level(self):
+        min_access_level = 60 # instance admin
+        for level in self.info['merge_access_levels']:
+            if level['access_level'] < min_access_level:
+                min_access_level = level['access_level']
+        return min_access_level

--- a/tests/test_merge_request.py
+++ b/tests/test_merge_request.py
@@ -30,8 +30,8 @@ INFO = {
 DISCUSSION = {
     'id': 'aabbcc0044',
     'notes': [
-        {'id': 12, "body": "assigned to @john_smith", "created_at": "2020-08-04T06:56:11.854Z"},
-        {'id': 13, "body": "assigned to @john_smith", "created_at": "2020-08-18T06:52:58.093Z"}
+        {'id': 12, 'author': {'id': 42}, "body": "assigned to @john_smith", "created_at": "2020-08-04T06:56:11.854Z"},
+        {'id': 13, 'author': {'id': 69}, "body": "assigned to @john_smith", "created_at": "2020-08-18T06:52:58.093Z"}
     ],
 }
 
@@ -214,19 +214,19 @@ class TestMergeRequest:
         ))
         assert [mr.info for mr in result] == [mr1, mr2]
 
-    def test_fetch_assigned_at(self):
+    def fetch_assigned_author_and_at(self):
         api = self.api
         dis1, dis2 = DISCUSSION, dict(DISCUSSION, id=679)
         mr1 = INFO
         user = marge.user.User(api=None, info=dict(USER_INFO, id=_MARGE_ID))
         api.collect_all_pages = Mock(return_value=[dis1, dis2])
-        result = MergeRequest.fetch_assigned_at(
+        result = MergeRequest.fetch_assigned_author_and_at(
             user=user, api=api, merge_request=mr1
         )
         api.collect_all_pages.assert_called_once_with(GET(
             '/projects/1234/merge_requests/54/discussions',
         ))
-        assert result == 1597733578.093
+        assert result == [69, 1597733578.093]
 
     def _load(self, json):
         old_mock = self.api.call


### PR DESCRIPTION
This ensures that the user who assigned marge bot to a merge request is a member of the project and has the required access level for the target branch.

Otherwise, any user that can assign merge requests could merge into branches marge-bot has access to.